### PR TITLE
Add Account, Login, and Sign-Up Components

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,12 @@ import PackageDescription
 
 let package = Package(
     name: "CardinalKit",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v16)
     ],
     products: [
+        .library(name: "Account", targets: ["Account"]),
         .library(name: "CardinalKit", targets: ["CardinalKit"]),
         .library(name: "HealthKitDataSource", targets: ["HealthKitDataSource"]),
         .library(name: "LocalStorage", targets: ["LocalStorage"]),
@@ -24,6 +26,15 @@ let package = Package(
         .library(name: "XCTRuntimeAssertions", targets: ["XCTRuntimeAssertions"])
     ],
     targets: [
+        .target(
+            name: "Account",
+            dependencies: [
+                .target(name: "CardinalKit")
+            ],
+            resources: [
+                .process("Resources")
+            ]
+        ),
         .target(
             name: "CardinalKit",
             dependencies: [

--- a/Sources/Account/Account.swift
+++ b/Sources/Account/Account.swift
@@ -1,0 +1,30 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import SwiftUI
+
+
+open class Account: ObservableObject, ObservableObjectComponent, TypedCollectionKey, DefaultInitializable {
+    public typealias Value = Account
+    
+    
+    open lazy var loginServices: [any AccountService] = [
+        UsernamePasswordLoginService(account: self),
+        EmailPasswordLoginService(account: self)
+    ]
+    open var user: User?
+    
+    
+    public var observableObject: Account {
+        self
+    }
+    
+    
+    public required init() {}
+}

--- a/Sources/Account/AccountService.swift
+++ b/Sources/Account/AccountService.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+public protocol AccountService: Identifiable {
+    var loginButton: AnyView { get }
+    var registerButton: AnyView { get }
+    
+    
+    init(account: Account)
+}
+
+
+extension AccountService {
+    public var registerButton: AnyView {
+        loginButton
+    }
+    
+    public var id: String {
+        String(describing: type(of: self))
+    }
+}

--- a/Sources/Account/Email and Password/EmailPasswordLoginService.swift
+++ b/Sources/Account/Email and Password/EmailPasswordLoginService.swift
@@ -1,0 +1,47 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import SwiftUI
+
+
+class EmailPasswordLoginService: UsernamePasswordLoginService {
+    private var validationRules: [ValidationRule] {
+        guard let regex = try? Regex("[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}") else {
+            return []
+        }
+        
+        return [
+            ValidationRule(
+                regex: regex,
+                message: String(localized: "LOGIN_EAP_EMAIL_VERIFICATION_ERROR", bundle: .module)
+            )
+        ]
+    }
+    
+    override var loginButton: AnyView {
+        AnyView(
+            NavigationLink {
+                UsernamePasswordLoginView(
+                    viewLocalization: UsernamePasswordLoginViewLocalization(
+                        usernameTitle: String(localized: "LOGIN_EAP_USERNAME_TITLE", bundle: .module),
+                        usernamePlaceholder: String(localized: "LOGIN_EAP_USERNAME_PLACEHOLDER", bundle: .module)
+                    ),
+                    usernameValidationRules: validationRules
+                )
+                    .environmentObject(self as UsernamePasswordLoginService)
+            } label: {
+                UsernamePasswordLoginServiceButton {
+                    Image(systemName: "envelope.fill")
+                        .font(.title2)
+                    Text("LOGIN_EAP_BUTTON_TITLE", bundle: .module)
+                }
+            }
+        )
+    }
+}

--- a/Sources/Account/Login.swift
+++ b/Sources/Account/Login.swift
@@ -1,0 +1,57 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import SwiftUI
+
+
+public struct Login<Header: View>: View {
+    @EnvironmentObject var account: Account
+    
+    private var header: Header
+    
+    
+    public var body: some View {
+        GeometryReader { proxy in
+            ScrollView(.vertical) {
+                VStack {
+                    header
+                    Spacer(minLength: 0)
+                    VStack(spacing: 16) {
+                        ForEach(account.loginServices, id: \.id) { loginService in
+                            loginService.loginButton
+                        }
+                    }
+                        .padding(16)
+                }
+                    .frame(minHeight: proxy.size.height)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+            .navigationTitle(String(localized: "LOGIN", bundle: .module))
+    }
+    
+    
+    public init() where Header == EmptyView {
+        self.header = EmptyView()
+    }
+    
+    public init(header: Header) {
+        self.header = header
+    }
+}
+
+
+struct Login_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            Login()
+        }
+            .environmentObject(Account())
+    }
+}

--- a/Sources/Account/Resources/de.lproj/Localizable.strings
+++ b/Sources/Account/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,19 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+"LOGIN" = "Anmelden";
+
+
+// Username Password Login View
+"LOGIN_UAP_NAVIGATION_TITLE" = "Anmelden";
+"LOGIN_UAP_USERNAME_TITLE" = "Benutzername";
+"LOGIN_UAP_PASSWORD_TITLE" = "Passwort";
+"LOGIN_UAP_USERNAME_PLACEHOLDER" = "Benutzername eingeben ...";
+"LOGIN_UAP_PASSWORD_PLACEHOLDER" = "Passwort eingeben ...";
+"LOGIN_UAP_LOGIN_BUTTON_TITLE" = "Anmelden";
+"LOGIN_UAP_DEFAULT_ERROR" = "Anmelden Fehlgeschlagen";

--- a/Sources/Account/Resources/en.lproj/Localizable.strings
+++ b/Sources/Account/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,26 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+"LOGIN" = "Login";
+
+// Username Password Login View
+"LOGIN_UAP_BUTTON_TITLE" = "Username and Password";
+"LOGIN_UAP_NAVIGATION_TITLE" = "Login";
+"LOGIN_UAP_USERNAME_TITLE" = "Username";
+"LOGIN_UAP_PASSWORD_TITLE" = "Password";
+"LOGIN_UAP_USERNAME_PLACEHOLDER" = "Enter your username ...";
+"LOGIN_UAP_PASSWORD_PLACEHOLDER" = "Enter your password ...";
+"LOGIN_UAP_LOGIN_BUTTON_TITLE" = "Login";
+"LOGIN_UAP_DEFAULT_ERROR" = "Login Failed";
+
+
+// Email Password Login View
+"LOGIN_EAP_BUTTON_TITLE" = "Email and Password";
+"LOGIN_EAP_USERNAME_TITLE" = "Email";
+"LOGIN_EAP_USERNAME_PLACEHOLDER" = "Enter your email ...";
+"LOGIN_EAP_EMAIL_VERIFICATION_ERROR" = "Please enter a valid email";

--- a/Sources/Account/User.swift
+++ b/Sources/Account/User.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+
+public struct User {
+    let name: PersonNameComponents
+    private let imageLoader: () async -> Image?
+    
+    
+    var image: Image? {
+        get async {
+            await imageLoader()
+        }
+    }
+    
+    
+    public init(name: PersonNameComponents, imageLoader: @escaping () async -> Image? = { nil }) {
+        self.name = name
+        self.imageLoader = imageLoader
+    }
+}

--- a/Sources/Account/UserProfileView.swift
+++ b/Sources/Account/UserProfileView.swift
@@ -1,0 +1,95 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+public struct UserProfileView: View {
+    private var user: User
+    @State private var image: Image? = nil
+    
+    
+    public var body: some View {
+        GeometryReader { context in
+            ZStack {
+                if let image {
+                    Circle()
+                        .foregroundColor(Color(.systemBackground))
+                    image.resizable()
+                        .clipShape(Circle())
+                } else {
+                    Circle()
+                        .foregroundColor(Color(.systemGray3))
+                    Text(user.name.formatted(.name(style: .abbreviated)))
+                        .foregroundColor(.init(UIColor.systemBackground))
+                        .font(
+                            .system(
+                                size: min(context.size.height, context.size.width) * 0.45,
+                                weight: .medium,
+                                design: .rounded
+                            )
+                        )
+                }
+            }.frame(
+                width: min(context.size.height, context.size.width),
+                height: min(context.size.height, context.size.width)
+            )
+        }
+            .aspectRatio(1, contentMode: .fit)
+            .contentShape(Circle())
+            .task {
+                self.image = await user.image
+            }
+    }
+    
+    
+    public init(user: User) {
+        self.user = user
+    }
+}
+
+
+struct ProfilePictureView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 16) {
+            UserProfileView(
+                user: User(
+                    name: PersonNameComponents(givenName: "Paul", familyName: "Schmiedmayer")
+                )
+            )
+                .frame(width: 100, height: 50)
+                .padding()
+            UserProfileView(
+                user: User(
+                    name: PersonNameComponents(
+                        namePrefix: "Prof.",
+                        givenName: "Oliver",
+                        middleName: "Oppers",
+                        familyName: "Aalami"
+                    )
+                )
+            )
+                .frame(width: 100, height: 100)
+                .padding()
+                .background(Color(.systemBackground))
+                .colorScheme(.dark)
+            UserProfileView(
+                user: User(
+                    name: PersonNameComponents(givenName: "Vishnu", familyName: "Ravi"),
+                    imageLoader: {
+                        try? await Task.sleep(for: .seconds(2))
+                        return Image(systemName: "person.crop.artframe")
+                    }
+                )
+            )
+                .frame(width: 50, height: 100)
+                .shadow(radius: 4)
+                .padding()
+        }
+    }
+}

--- a/Sources/Account/Username and Password/UsernamePasswordLoginService.swift
+++ b/Sources/Account/Username and Password/UsernamePasswordLoginService.swift
@@ -1,0 +1,45 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import SwiftUI
+
+
+class UsernamePasswordLoginService: AccountService, ObservableObject {
+    weak var account: Account?
+    
+    
+    open var loginButton: AnyView {
+        AnyView(
+            NavigationLink {
+                UsernamePasswordLoginView()
+                    .environmentObject(self as UsernamePasswordLoginService)
+            } label: {
+                UsernamePasswordLoginServiceButton {
+                    Image(systemName: "ellipsis.rectangle")
+                        .font(.title2)
+                    Text("LOGIN_UAP_BUTTON_TITLE", bundle: .module)
+                }
+            }
+        )
+    }
+    
+    
+    required init(account: Account) {
+        self.account = account
+    }
+    
+    
+    func login(username: String, password: String) async throws {
+        try await Task.sleep(for: .seconds(5))
+        account?.user = User(name: PersonNameComponents(givenName: "Leland", familyName: "Stanford")) {
+            try? await Task.sleep(for: .seconds(2))
+            return Image(systemName: "person.fill")
+        }
+    }
+}

--- a/Sources/Account/Username and Password/UsernamePasswordLoginServiceButton.swift
+++ b/Sources/Account/Username and Password/UsernamePasswordLoginServiceButton.swift
@@ -1,0 +1,44 @@
+//
+//  SwiftUIView.swift
+//  
+//
+//  Created by Paul Shmiedmayer on 11/20/22.
+//
+
+import SwiftUI
+
+struct UsernamePasswordLoginServiceButton<Content: View>: View {
+    private let content: Content
+    
+    
+    var body: some View {
+        HStack {
+            content
+        }
+            .foregroundColor(.accentColor)
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 15)
+                    .stroke(Color.accentColor, lineWidth: 2)
+                    .padding(1)
+            )
+            .cornerRadius(8)
+    }
+    
+    
+    init(@ViewBuilder _ content: () -> Content) {
+        self.content = content()
+    }
+}
+
+
+struct SwiftUIView_Previews: PreviewProvider {
+    static var previews: some View {
+        UsernamePasswordLoginServiceButton() {
+            Image(systemName: "ellipsis.rectangle")
+                .font(.title2)
+            Text("LOGIN_UAP_BUTTON_TITLE", bundle: .module)
+        }
+    }
+}

--- a/Sources/Account/Username and Password/UsernamePasswordLoginView.swift
+++ b/Sources/Account/Username and Password/UsernamePasswordLoginView.swift
@@ -1,0 +1,272 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+private enum UsernamePasswordLoginViewState: Equatable {
+    case idle
+    case processing
+    case error(Error)
+    
+    
+    var errorTitle: String {
+        switch self {
+        case let .error(error as LocalizedError):
+            return error.errorDescription
+                ?? String(localized: "LOGIN_UAP_DEFAULT_ERROR", bundle: .module)
+        default:
+            return String(localized: "LOGIN_UAP_DEFAULT_ERROR", bundle: .module)
+        }
+    }
+    
+    var errorDescription: String {
+        switch self {
+        case let .error(error as LocalizedError):
+            var errorDescription = ""
+            if let failureReason = error.failureReason {
+                errorDescription.append("\(failureReason)\n\n")
+            }
+            if let helpAnchor = error.helpAnchor {
+                errorDescription.append("\(helpAnchor)\n\n")
+            }
+            if let recoverySuggestion = error.recoverySuggestion {
+                errorDescription.append("\(recoverySuggestion)\n\n")
+            }
+            if errorDescription.isEmpty {
+                errorDescription = error.localizedDescription
+            }
+            return errorDescription
+        case let .error(error):
+            return error.localizedDescription
+        default:
+            return ""
+        }
+    }
+    
+    static func == (lhs: UsernamePasswordLoginViewState, rhs: UsernamePasswordLoginViewState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.processing, .processing), (.error, .error):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+
+struct UsernamePasswordLoginView<Header: View, Footer: View>: View {
+    enum Field: Hashable {
+        case username
+        case password
+    }
+    
+    
+    private let viewLocalization: UsernamePasswordLoginViewLocalization
+    private let usernameValidationRules: [ValidationRule]
+    private let passwordValidationRules: [ValidationRule]
+    private let header: Header
+    private let footer: Footer
+    
+    @EnvironmentObject private var usernamePasswordLoginService: UsernamePasswordLoginService
+    
+    @State private var username: String = ""
+    @State private var usernameValidationResults: [String] = []
+    @State private var password: String = ""
+    @State private var passwordValidationResults: [String] = []
+    @FocusState private var focusedField: Field?
+    @State private var state: UsernamePasswordLoginViewState = .idle
+    
+    
+    var body: some View {
+        ScrollView {
+            header
+            Divider()
+            Grid(horizontalSpacing: 16, verticalSpacing: 0) {
+                GridRow {
+                    Text(viewLocalization.usernameTitle)
+                        .fontWeight(.semibold)
+                        .gridColumnAlignment(.leading)
+                    TextField(viewLocalization.usernamePlaceholder, text: $username)
+                        .frame(maxWidth: .infinity)
+                        .focused($focusedField, equals: .username)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                        .onSubmit {
+                            usernameValidation()
+                        }
+                }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        focusedField = .username
+                    }
+                    .padding(.vertical, 8)
+                GridRow {
+                    Spacer(minLength: 0)
+                    HStack() {
+                        ForEach(usernameValidationResults, id: \.self) { message in
+                            Text(message)
+                        }
+                    }
+                        .gridColumnAlignment(.leading)
+                        .font(.footnote)
+                        .foregroundColor(.red)
+                }
+                Divider()
+                    .padding(.vertical, 10)
+                GridRow {
+                    Text(viewLocalization.passwordTitle)
+                        .fontWeight(.semibold)
+                        .gridColumnAlignment(.leading)
+                    SecureField(viewLocalization.passwordPlaceholder, text: $password)
+                        .frame(maxWidth: .infinity)
+                        .focused($focusedField, equals: .password)
+                        .onSubmit {
+                            passwordValidation()
+                        }
+                }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        focusedField = .password
+                    }
+                    .padding(.vertical, 10)
+                    .padding(.bottom, -0.1)
+                GridRow {
+                    Spacer(minLength: 0)
+                    HStack() {
+                        ForEach(passwordValidationResults, id: \.self) { message in
+                            Text(message)
+                        }
+                    }
+                        .gridColumnAlignment(.leading)
+                        .font(.footnote)
+                        .foregroundColor(.red)
+                }
+            }
+                .padding(.leading, 16)
+            Divider()
+            Button(action: loginButtonPressed) {
+                Text(viewLocalization.loginButtonTitle)
+                    .padding(6)
+                    .frame(maxWidth: .infinity)
+                    .opacity(state == .processing ? 0.0 : 1.0)
+                    .overlay {
+                        if state == .processing {
+                            ProgressView()
+                        }
+                    }
+            }
+                .buttonStyle(.borderedProminent)
+                .disabled(loginButtonDisabled)
+                .padding()
+            footer
+        }
+            .navigationTitle(viewLocalization.navigationTitle)
+            .navigationBarBackButtonHidden(state == .processing)
+            .alert(state.errorTitle, isPresented: errorAlertBinding) {
+                Text(state.errorDescription)
+            }
+            .onTapGesture {
+                focusedField = nil
+            }
+            .onChange(of: focusedField) { _ in
+                usernameValidation()
+                passwordValidation()
+            }
+    }
+    
+    private var errorAlertBinding: Binding<Bool> {
+        Binding {
+            if case .error = state {
+                return true
+            } else {
+                return false
+            }
+        } set: { newValue in
+            state = .idle
+        }
+    }
+    
+    private var loginButtonDisabled: Bool {
+        state == .processing
+            || username.isEmpty
+            || password.isEmpty
+            || !usernameValidationResults.isEmpty
+            || !passwordValidationResults.isEmpty
+    }
+    
+    
+    init(
+        viewLocalization: UsernamePasswordLoginViewLocalization = .default,
+        usernameValidationRules: [ValidationRule] = [],
+        passwordValidationRules: [ValidationRule] = [],
+        @ViewBuilder header: () -> Header = { EmptyView() },
+        @ViewBuilder footer: () -> Footer = { EmptyView() }
+    ) {
+        self.viewLocalization = viewLocalization
+        self.usernameValidationRules = usernameValidationRules
+        self.passwordValidationRules = passwordValidationRules
+        self.header = header()
+        self.footer = footer()
+    }
+    
+    
+    private func loginButtonPressed() {
+        guard !(state == .processing) else {
+            return
+        }
+        
+        withAnimation(.easeOut(duration: 0.2)) {
+            focusedField = .none
+            state = .processing
+        }
+        
+        Task {
+            do {
+                try await usernamePasswordLoginService.login(username: username, password: password)
+            } catch {
+                state = .error(error)
+            }
+            withAnimation(.easeIn(duration: 0.2)) {
+                state = .idle
+            }
+        }
+    }
+    
+    private func usernameValidation() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            guard !username.isEmpty else {
+                usernameValidationResults = []
+                return
+            }
+            
+            usernameValidationResults = usernameValidationRules.compactMap { $0.validate(username) }
+        }
+    }
+    
+    private func passwordValidation() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            guard !password.isEmpty else {
+                passwordValidationResults = []
+                return
+            }
+            
+            passwordValidationResults = passwordValidationRules.compactMap { $0.validate(password) }
+        }
+    }
+}
+
+
+struct UsernamePasswordLoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            UsernamePasswordLoginView()
+                .environmentObject(UsernamePasswordLoginService(account: Account()))
+        }
+    }
+}

--- a/Sources/Account/Username and Password/UsernamePasswordLoginViewLocalization.swift
+++ b/Sources/Account/Username and Password/UsernamePasswordLoginViewLocalization.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+public struct UsernamePasswordLoginViewLocalization {
+    public let navigationTitle: String
+    public let usernameTitle: String
+    public let passwordTitle: String
+    public let usernamePlaceholder: String
+    public let passwordPlaceholder: String
+    public let loginButtonTitle: String
+    
+    
+    public static let `default` = UsernamePasswordLoginViewLocalization(
+        navigationTitle: String(localized: "LOGIN_UAP_NAVIGATION_TITLE", bundle: .module),
+        usernameTitle: String(localized: "LOGIN_UAP_USERNAME_TITLE", bundle: .module),
+        passwordTitle: String(localized: "LOGIN_UAP_PASSWORD_TITLE", bundle: .module),
+        usernamePlaceholder: String(localized: "LOGIN_UAP_USERNAME_PLACEHOLDER", bundle: .module),
+        passwordPlaceholder: String(localized: "LOGIN_UAP_PASSWORD_PLACEHOLDER", bundle: .module),
+        loginButtonTitle: String(localized: "LOGIN_UAP_LOGIN_BUTTON_TITLE", bundle: .module)
+    )
+    
+    
+    public init(
+        navigationTitle: String = `default`.navigationTitle,
+        usernameTitle: String = `default`.usernameTitle,
+        passwordTitle: String = `default`.passwordTitle,
+        usernamePlaceholder: String = `default`.usernamePlaceholder,
+        passwordPlaceholder: String = `default`.passwordPlaceholder,
+        loginButtonTitle: String = `default`.loginButtonTitle
+    ) {
+        self.navigationTitle = navigationTitle
+        self.usernameTitle = usernameTitle
+        self.passwordTitle = passwordTitle
+        self.usernamePlaceholder = usernamePlaceholder
+        self.passwordPlaceholder = passwordPlaceholder
+        self.loginButtonTitle = loginButtonTitle
+    }
+}

--- a/Sources/Account/ValidationRule.swift
+++ b/Sources/Account/ValidationRule.swift
@@ -1,0 +1,52 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+struct ValidationRule: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case rule
+        case message
+    }
+    
+    
+    private let rule: (String) -> Bool
+    private let message: String
+    
+    
+    init(rule: @escaping (String) -> Bool, message: String) {
+        self.rule = rule
+        self.message = message
+    }
+    
+    init(regex: Regex<AnyRegexOutput>, message: String) {
+        self.rule = { input in
+            (try? regex.wholeMatch(in: input) != nil) ?? false
+        }
+        self.message = message
+    }
+    
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let regexString = try values.decode(String.self, forKey: .rule)
+        let regex = try Regex<AnyRegexOutput>(regexString)
+        
+        let message = try values.decode(String.self, forKey: .message)
+        
+        self.init(regex: regex, message: message)
+    }
+    
+    
+    func validate(_ input: String) -> String? {
+        guard !rule(input) else {
+            return nil
+        }
+        
+        return message
+    }
+}

--- a/Sources/CardinalKit/CardinalKit/Infrastructure/TypedCollection.swift
+++ b/Sources/CardinalKit/CardinalKit/Infrastructure/TypedCollection.swift
@@ -22,6 +22,16 @@ public protocol TypedCollectionKey<Value> {
     associatedtype Value = Self
 }
 
+extension TypedCollectionKey {
+    func saveInTypedCollection(cardinalKit: AnyCardinalKit) {
+        guard let value = self as? Value else {
+            return
+        }
+        
+        cardinalKit.typedCollection.set(Self.self, to: value)
+    }
+}
+
 
 /// Type erasure for `TypedCollection.Value`
 private protocol AnyTypedCollectionValue {

--- a/Sources/CardinalKit/Configuration/Component.swift
+++ b/Sources/CardinalKit/Configuration/Component.swift
@@ -8,7 +8,7 @@
 
 
 /// A ``Component`` defines
-public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey where Value == Self {
+public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey {
     /// A ``Component/ComponentStandard`` defines what ``Standard`` the component supports.
     associatedtype ComponentStandard: Standard
     
@@ -19,11 +19,7 @@ public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey wher
 }
 
 
-extension Component {
-    func saveInTypedCollection(cardinalKit: CardinalKit<ComponentStandard>) {
-        cardinalKit.typedCollection.set(Self.self, to: self)
-    }
-    
+extension Component {    
     // A documentation for this methodd exists in the `Component` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
     public func configure() {}

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Account
 
 
 @main
@@ -45,13 +46,15 @@ struct UITestsApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                List(Tests.allCases) { test in
-                    NavigationLink(test.rawValue, value: test)
-                }
-                    .navigationDestination(for: Tests.self) { test in
-                        test.view
-                    }
-                    .navigationTitle("UITest")
+                Login()
+                    .environmentObject(Account())
+//                List(Tests.allCases) { test in
+//                    NavigationLink(test.rawValue, value: test)
+//                }
+//                    .navigationDestination(for: Tests.self) { test in
+//                        test.view
+//                    }
+//                    .navigationTitle("UITest")
             }
                 .cardinalKit(appDelegate)
         }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2FC2C406291D84A600712676 /* HealthKitTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC2C405291D84A600712676 /* HealthKitTestsView.swift */; };
 		2FC2C408291DCC8200712676 /* HealthKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC2C407291DCC8200712676 /* HealthKitTests.swift */; };
 		2FC42FD9290ADD8800B08F18 /* CardinalKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2FC42FD8290ADD8800B08F18 /* CardinalKit */; };
+		2FD68DE3292971730043AB73 /* Account in Frameworks */ = {isa = PBXBuildFile; productRef = 2FD68DE2292971730043AB73 /* Account */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FD68DE3292971730043AB73 /* Account in Frameworks */,
 				2FB77B9E2910EF13009FDDE2 /* LocalStorage in Frameworks */,
 				2F67A5BA290C69640092CAD6 /* SecureStorage in Frameworks */,
 				2F01E8CC29148D120089C46B /* HealthKitDataSource in Frameworks */,
@@ -223,6 +225,7 @@
 				2F67A5B9290C69640092CAD6 /* SecureStorage */,
 				2FB77B9D2910EF13009FDDE2 /* LocalStorage */,
 				2F01E8CB29148D120089C46B /* HealthKitDataSource */,
+				2FD68DE2292971730043AB73 /* Account */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -620,6 +623,10 @@
 		2FC42FD8290ADD8800B08F18 /* CardinalKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CardinalKit;
+		};
+		2FD68DE2292971730043AB73 /* Account */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Account;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
# Add Account and Login Views

## :recycle: Current situation & Problem
Developers of mobile applications typically need to implement a login functionality for different Account services, including a username/email and password-based login.

## :bulb: Proposed solution
This PR adds the Account module that induces components to handle user views, login views, and sign-up views that enable reusability across different applications.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
