### PR TITLE
 Observable Object Provider

### DIFF
--- a/Sources/CardinalKit/CardinalKit/Infrastructure/TypedCollection.swift
+++ b/Sources/CardinalKit/CardinalKit/Infrastructure/TypedCollection.swift
@@ -16,13 +16,6 @@
 import os
 
 
-/// Key used to identify stored elements in `TypedCollection` instances.
-public protocol TypedCollectionKey<Value> {
-    /// The value type associated with the `TypedCollectionKey`.
-    associatedtype Value = Self
-}
-
-
 /// Type erasure for `TypedCollection.Value`
 private protocol AnyTypedCollectionValue {
     var anyValue: Any { get }

--- a/Sources/CardinalKit/CardinalKit/Infrastructure/TypedCollectionKey.swift
+++ b/Sources/CardinalKit/CardinalKit/Infrastructure/TypedCollectionKey.swift
@@ -1,0 +1,24 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+/// Key used to identify stored elements in `TypedCollection` instances.
+public protocol TypedCollectionKey<Value> {
+    /// The value type associated with the `TypedCollectionKey`.
+    associatedtype Value = Self
+}
+
+extension TypedCollectionKey {
+    func saveInTypedCollection(cardinalKit: AnyCardinalKit) {
+        guard let value = self as? Value else {
+            return
+        }
+        
+        cardinalKit.typedCollection.set(Self.self, to: value)
+    }
+}

--- a/Sources/CardinalKit/CardinalKit/View+CardinalKit.swift
+++ b/Sources/CardinalKit/CardinalKit/View+CardinalKit.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 
 struct CardinalKitViewModifier: ViewModifier {
-    var observableObjectProviders: [any ObservableObjectComponent]
+    var observableObjectProviders: [any ObservableObjectProvider]
     
     
     init(_ anyCardinalKit: AnyCardinalKit) {

--- a/Sources/CardinalKit/Configuration/Component.swift
+++ b/Sources/CardinalKit/Configuration/Component.swift
@@ -8,7 +8,7 @@
 
 
 /// A ``Component`` defines
-public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey where Value == Self {
+public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey {
     /// A ``Component/ComponentStandard`` defines what ``Standard`` the component supports.
     associatedtype ComponentStandard: Standard
     
@@ -20,10 +20,6 @@ public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey wher
 
 
 extension Component {
-    func saveInTypedCollection(cardinalKit: CardinalKit<ComponentStandard>) {
-        cardinalKit.typedCollection.set(Self.self, to: self)
-    }
-    
     // A documentation for this methodd exists in the `Component` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
     public func configure() {}

--- a/Sources/CardinalKit/Module/Capabilities/ObservableObject/CardinalKit+ObservableObjects.swift
+++ b/Sources/CardinalKit/Module/Capabilities/ObservableObject/CardinalKit+ObservableObjects.swift
@@ -11,22 +11,18 @@ import SwiftUI
 
 extension AnyCardinalKit {
     /// A collection of ``CardinalKit/CardinalKit`` `LifecycleHandler`s.
-    var observableObjectProviders: [any ObservableObjectComponent] {
-        typedCollection.get(allThatConformTo: (any ObservableObjectComponent).self)
+    var observableObjectProviders: [any ObservableObjectProvider] {
+        typedCollection.get(allThatConformTo: (any ObservableObjectProvider).self)
     }
 }
 
 
 extension View {
-    func inject(observableObjectProviders: [any ObservableObjectComponent]) -> some View {
+    func inject(observableObjectProviders: [any ObservableObjectProvider]) -> some View {
         var injectedView = AnyView(self)
         for observableObjectProvider in observableObjectProviders {
-            injectedView = injectedView.inject(observableObjectProvider.viewModifier)
+            injectedView = observableObjectProvider.inject(in: injectedView)
         }
         return injectedView
-    }
-    
-    private func inject(_ modifier: some ViewModifier) -> AnyView {
-        AnyView(self.modifier(modifier))
     }
 }

--- a/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
+++ b/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
@@ -16,7 +16,7 @@ public protocol ObservableObjectProvider {
 }
 
 
-private struct ObservableObjectInjectionViewModifie: ViewModifier {
+private struct ObservableObjectInjectionViewModifier: ViewModifier {
     let apply: (AnyView) -> AnyView
     
     
@@ -44,7 +44,7 @@ extension ObservableObjectProvider {
     func inject(in view: AnyView) -> AnyView {
         var view = view
         for observableObject in observableObjects {
-            let modifier = ObservableObjectInjectionViewModifie(observableObject: observableObject)
+            let modifier = ObservableObjectInjectionViewModifier(observableObject: observableObject)
             view = AnyView(view.modifier(modifier))
         }
         return view

--- a/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
+++ b/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
@@ -9,38 +9,52 @@
 import SwiftUI
 
 
-private struct ObservableObjectInjectionViewModifier<O: ObservableObject>: ViewModifier {
-    let observableObject: O
+/// A ``Component`` can conform to ``ObservableObjectProvider`` to inject an ``ObservableObject``s in the SwiftUI view hierachy using ``ObservableObjectProvider/observableObjects``
+public protocol ObservableObjectProvider {
+    /// The ``ObservableObject`` instances that should be injected in the SwiftUI environment.
+    var observableObjects: [any ObservableObject] { get }
+}
+
+
+private struct ObservableObjectInjectionViewModifie: ViewModifier {
+    let apply: (AnyView) -> AnyView
+    
+    
+    init<O: ObservableObject>(observableObject: O) {
+        apply = { view in
+            AnyView(view.environmentObject(observableObject))
+        }
+    }
     
     
     func body(content: Content) -> some View {
-        content.environmentObject(observableObject)
+        apply(AnyView(content))
     }
 }
 
 
-/// A ``Component`` can conform to ``ObservableObjectComponent`` to inject an ``ObservableObject`` in the SwiftUI view hierachy.
-public protocol ObservableObjectComponent {
-    /// The ``ObservableObjectComponent/InjectedObject`` defines the type that will be injected into the SwiftUI environment.
-    associatedtype InjectedObject: ObservableObject
-    
-    
-    /// The ``ObservableObject`` instance that should be injected in the SwiftUI environment.
-    var observableObject: InjectedObject { get }
-}
-
-
-extension ObservableObjectComponent where Self: ObservableObject {
-    // A documentation for this methodd exists in the `ObservableObjectComponent` type which SwiftLint doesn't recognize.
+extension ObservableObjectProvider {
+    // A documentation for this methodd exists in the `ObservableObjectProvider` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
-    public var observableObject: Self {
-        self
+    public var observableObjects: [any ObservableObject] {
+        []
+    }
+    
+    
+    func inject(in view: AnyView) -> AnyView {
+        var view = view
+        for observableObject in observableObjects {
+            let modifier = ObservableObjectInjectionViewModifie(observableObject: observableObject)
+            view = AnyView(view.modifier(modifier))
+        }
+        return view
     }
 }
 
-
-extension ObservableObjectComponent {
-    var viewModifier: some ViewModifier {
-        ObservableObjectInjectionViewModifier(observableObject: observableObject)
+extension ObservableObjectProvider where Self: ObservableObject {
+    // A documentation for this methodd exists in the `ObservableObjectProvider` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public var observableObjects: [any ObservableObject] {
+        [self]
     }
 }

--- a/Sources/CardinalKit/Module/Module.swift
+++ b/Sources/CardinalKit/Module/Module.swift
@@ -9,5 +9,5 @@
 import SwiftUI
 
 
-/// A ``Module`` is a larger ``Component`` that is a ``LifecycleHandler``, persisted in the ``CardinalKit`` instance's ``CardinalKit/CardinalKit/typedCollection`` (using a conformance to ``TypedCollectionKey``), injected in the SwiftUI view hierachy (``ObservableObjectComponent`` & ``ObservableObject``), and defined ``Component`` dependencies using ``DependingComponent``.
-public typealias Module = Component & LifecycleHandler & ObservableObjectComponent & ObservableObject & TypedCollectionKey
+/// A ``Module`` is a larger ``Component`` that is a ``LifecycleHandler``, persisted in the ``CardinalKit`` instance's ``CardinalKit/CardinalKit/typedCollection`` (using a conformance to ``TypedCollectionKey``), injected in the SwiftUI view hierachy (``ObservableObjectProvider`` & ``ObservableObject``), and defined ``Component`` dependencies using ``DependingComponent``.
+public typealias Module = Component & LifecycleHandler & ObservableObjectProvider & ObservableObject & TypedCollectionKey

--- a/Sources/HealthKitDataSource/HealthKit.swift
+++ b/Sources/HealthKitDataSource/HealthKit.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 
 /// <#Description#>
-public final class HealthKit<ComponentStandard: Standard>: Component, ObservableObject, ObservableObjectComponent {
+public final class HealthKit<ComponentStandard: Standard>: Component, ObservableObject, ObservableObjectProvider {
     /// <#Description#>
     public typealias Adapter = any DataSourceRegistryAdapter<HKSample, ComponentStandard.BaseType>
     

--- a/Tests/CardinalKitTests/Shared/TestComponent.swift
+++ b/Tests/CardinalKitTests/Shared/TestComponent.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @_exported import XCTest
 
 
-public final class TestComponent<ComponentStandard: Standard>: ObservableObject, Component, ObservableObjectComponent {
+public final class TestComponent<ComponentStandard: Standard>: ObservableObject, Component, ObservableObjectProvider {
     let expectation: XCTestExpectation
     
     

--- a/Tests/UITests/TestApp/ObservableObjectTests/MultipleObservableObjectsTestsComponent.swift
+++ b/Tests/UITests/TestApp/ObservableObjectTests/MultipleObservableObjectsTestsComponent.swift
@@ -1,0 +1,30 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import SwiftUI
+
+
+final class MultipleObservableObjectsTestsComponent<ComponentStandard: Standard>: Module {
+    class TestObservableObject<T>: ObservableObject {
+        let value: T
+        
+        
+        init(value: T) {
+            self.value = value
+        }
+    }
+    
+    
+    var observableObjects: [any ObservableObject] {
+        [
+            TestObservableObject(value: 42),
+            TestObservableObject(value: "42")
+        ]
+    }
+}

--- a/Tests/UITests/TestApp/ObservableObjectTests/ObservableObjectTests.swift
+++ b/Tests/UITests/TestApp/ObservableObjectTests/ObservableObjectTests.swift
@@ -10,15 +10,28 @@ import CardinalKit
 
 
 class ObservableObjectTests: TestAppTestCase {
-    let testAppComponent: ObservableComponentTestsComponent<TestAppStandard>
+    typealias ObservableComponent = ObservableComponentTestsComponent<TestAppStandard>
+    typealias MultipleObservableComponent = MultipleObservableObjectsTestsComponent<TestAppStandard>
+    
+    let testAppComponent: ObservableComponent
+    let multipleObservableInt: MultipleObservableComponent.TestObservableObject<Int>
+    let multipleObservableString: MultipleObservableComponent.TestObservableObject<String>
     
     
-    init(testAppComponent: ObservableComponentTestsComponent<TestAppStandard>) {
+    init(
+        testAppComponent: ObservableComponent,
+        multipleObservableInt: MultipleObservableComponent.TestObservableObject<Int>,
+        multipleObservableString: MultipleObservableComponent.TestObservableObject<String>
+    ) {
         self.testAppComponent = testAppComponent
+        self.multipleObservableInt = multipleObservableInt
+        self.multipleObservableString = multipleObservableString
     }
     
     
     func runTests() async throws {
         try XCTAssertEqual(testAppComponent.message, "Passed")
+        try XCTAssertEqual(multipleObservableInt.value, 42)
+        try XCTAssertEqual(multipleObservableString.value, "42")
     }
 }

--- a/Tests/UITests/TestApp/ObservableObjectTests/ObservableObjectTestsView.swift
+++ b/Tests/UITests/TestApp/ObservableObjectTests/ObservableObjectTestsView.swift
@@ -10,10 +10,22 @@ import SwiftUI
 
 
 struct ObservableObjectTestsView: View {
-    @EnvironmentObject var testAppComponent: ObservableComponentTestsComponent<TestAppStandard>
+    typealias ObservableComponent = ObservableComponentTestsComponent<TestAppStandard>
+    typealias MultipleObservableComponent = MultipleObservableObjectsTestsComponent<TestAppStandard>
+    
+    
+    @EnvironmentObject var testAppComponent: ObservableComponent
+    @EnvironmentObject var multipleObservableInt: MultipleObservableComponent.TestObservableObject<Int>
+    @EnvironmentObject var multipleObservableString: MultipleObservableComponent.TestObservableObject<String>
     
     
     var body: some View {
-        TestAppView(testCase: ObservableObjectTests(testAppComponent: testAppComponent))
+        TestAppView(
+            testCase: ObservableObjectTests(
+                testAppComponent: testAppComponent,
+                multipleObservableInt: multipleObservableInt,
+                multipleObservableString: multipleObservableString
+            )
+        )
     }
 }

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -18,6 +18,7 @@ class TestAppDelegate: CardinalKitAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: TestAppStandard()) {
             ObservableComponentTestsComponent(message: "Passed")
+            MultipleObservableObjectsTestsComponent()
             if HKHealthStore.isHealthDataAvailable() {
                 HealthKit {
                     CollectSample(

--- a/Tests/UITests/TestApp/Shared/TestAppStandard.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppStandard.swift
@@ -10,7 +10,7 @@ import CardinalKit
 import Foundation
 
 
-actor TestAppStandard: Standard, ObservableObjectComponent, ObservableObject {
+actor TestAppStandard: Standard, ObservableObjectProvider, ObservableObject {
     typealias BaseType = TestAppStandardDataSourceElement
     
     

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -13,7 +13,7 @@ class TestAppUITests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         
-        continueAfterFailure = true
+        continueAfterFailure = false
     }
     
     

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -8,11 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		2F01E8CC29148D120089C46B /* HealthKitDataSource in Frameworks */ = {isa = PBXBuildFile; productRef = 2F01E8CB29148D120089C46B /* HealthKitDataSource */; };
+		2F1BBE1E2942B62A0054656C /* TestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1BBE1D2942B62A0054656C /* TestAppUITests.swift */; };
 		2F2A354F291CCF74000E8373 /* TestAppHealthKitAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2A354E291CCF74000E8373 /* TestAppHealthKitAdapter.swift */; };
 		2F6051CC290C5BDC0003D458 /* XCTRuntimeAssertions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F6051CB290C5BDC0003D458 /* XCTRuntimeAssertions */; };
 		2F67A5BA290C69640092CAD6 /* SecureStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2F67A5B9290C69640092CAD6 /* SecureStorage */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
-		2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431229130A8C005D2B8F /* TestAppUITests.swift */; };
 		2F8A431529130B9B005D2B8F /* TestAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431429130B9B005D2B8F /* TestAppView.swift */; };
 		2F8A431729130BBC005D2B8F /* TestAppStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431629130BBC005D2B8F /* TestAppStandard.swift */; };
 		2F8A431929130CA7005D2B8F /* TestAppTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431829130CA7005D2B8F /* TestAppTestCase.swift */; };
@@ -30,6 +30,7 @@
 		2FB77B9E2910EF13009FDDE2 /* LocalStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2FB77B9D2910EF13009FDDE2 /* LocalStorage */; };
 		2FB77BA12910EF4A009FDDE2 /* LocalStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB77BA02910EF4A009FDDE2 /* LocalStorageTests.swift */; };
 		2FB77BA52910F84D009FDDE2 /* LocalStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB77BA42910F84D009FDDE2 /* LocalStorageTests.swift */; };
+		2FC246C82941376600F75383 /* MultipleObservableObjectsTestsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC246C72941376600F75383 /* MultipleObservableObjectsTestsComponent.swift */; };
 		2FC2C406291D84A600712676 /* HealthKitTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC2C405291D84A600712676 /* HealthKitTestsView.swift */; };
 		2FC2C408291DCC8200712676 /* HealthKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC2C407291DCC8200712676 /* HealthKitTests.swift */; };
 		2FC42FD9290ADD8800B08F18 /* CardinalKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2FC42FD8290ADD8800B08F18 /* CardinalKit */; };
@@ -48,11 +49,11 @@
 /* Begin PBXFileReference section */
 		2F01E8CD291490B80089C46B /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 		2F01E8CE291493560089C46B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		2F1BBE1D2942B62A0054656C /* TestAppUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAppUITests.swift; sourceTree = "<group>"; };
 		2F2A354E291CCF74000E8373 /* TestAppHealthKitAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppHealthKitAdapter.swift; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F8A431229130A8C005D2B8F /* TestAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppUITests.swift; sourceTree = "<group>"; };
 		2F8A431429130B9B005D2B8F /* TestAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppView.swift; sourceTree = "<group>"; };
 		2F8A431629130BBC005D2B8F /* TestAppStandard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAppStandard.swift; sourceTree = "<group>"; };
 		2F8A431829130CA7005D2B8F /* TestAppTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppTestCase.swift; sourceTree = "<group>"; };
@@ -69,6 +70,7 @@
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB77BA02910EF4A009FDDE2 /* LocalStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageTests.swift; sourceTree = "<group>"; };
 		2FB77BA42910F84D009FDDE2 /* LocalStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageTests.swift; sourceTree = "<group>"; };
+		2FC246C72941376600F75383 /* MultipleObservableObjectsTestsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleObservableObjectsTestsComponent.swift; sourceTree = "<group>"; };
 		2FC2C405291D84A600712676 /* HealthKitTestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitTestsView.swift; sourceTree = "<group>"; };
 		2FC2C407291DCC8200712676 /* HealthKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitTests.swift; sourceTree = "<group>"; };
 		2FC42FD7290ADD5E00B08F18 /* CardinalKitSPM */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = CardinalKitSPM; path = ../..; sourceTree = "<group>"; };
@@ -120,15 +122,15 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
+				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
+				2FC2C404291D848600712676 /* HealthKitTests */,
+				2F8A431C291316C8005D2B8F /* LocalStorageTests */,
+				2F8A431D291316CD005D2B8F /* ObservableObjectTests */,
+				2F8A431E291316D2005D2B8F /* SecureStorageTests */,
+				2F9F07ED29090AF500CDC598 /* Shared */,
+				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
 				2F01E8CE291493560089C46B /* Info.plist */,
 				2F01E8CD291490B80089C46B /* TestApp.entitlements */,
-				2F8A431E291316D2005D2B8F /* SecureStorageTests */,
-				2F8A431D291316CD005D2B8F /* ObservableObjectTests */,
-				2F8A431C291316C8005D2B8F /* LocalStorageTests */,
-				2FC2C404291D848600712676 /* HealthKitTests */,
-				2F9F07ED29090AF500CDC598 /* Shared */,
-				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
-				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
 			);
 			path = TestApp;
 			sourceTree = "<group>";
@@ -136,10 +138,10 @@
 		2F6D13AF28F5F386007C25D6 /* TestAppUITests */ = {
 			isa = PBXGroup;
 			children = (
+				2F1BBE1D2942B62A0054656C /* TestAppUITests.swift */,
 				2F9F07F429090BA900CDC598 /* ObservableObjectComponentTests.swift */,
 				2F9F07E1290906A200CDC598 /* SecureStorageTests.swift */,
 				2FB77BA42910F84D009FDDE2 /* LocalStorageTests.swift */,
-				2F8A431229130A8C005D2B8F /* TestAppUITests.swift */,
 				2FC2C407291DCC8200712676 /* HealthKitTests.swift */,
 			);
 			path = TestAppUITests;
@@ -166,6 +168,7 @@
 			children = (
 				2F8A431A29130EF0005D2B8F /* ObservableObjectTests.swift */,
 				2F8A43212913172E005D2B8F /* ObservableComponentTestsComponent.swift */,
+				2FC246C72941376600F75383 /* MultipleObservableObjectsTestsComponent.swift */,
 				2F8A43232913174B005D2B8F /* ObservableObjectTestsView.swift */,
 			);
 			path = ObservableObjectTests;
@@ -310,6 +313,7 @@
 				2F8A431929130CA7005D2B8F /* TestAppTestCase.swift in Sources */,
 				2F8A431529130B9B005D2B8F /* TestAppView.swift in Sources */,
 				2F8A43222913172E005D2B8F /* ObservableComponentTestsComponent.swift in Sources */,
+				2FC246C82941376600F75383 /* MultipleObservableObjectsTestsComponent.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				2F8A4326291317AA005D2B8F /* LocalStorageTestsView.swift in Sources */,
 				2F8A43242913174B005D2B8F /* ObservableObjectTestsView.swift in Sources */,
@@ -330,9 +334,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F9F07F529090BA900CDC598 /* ObservableObjectComponentTests.swift in Sources */,
-				2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */,
 				2F9F07E2290906A200CDC598 /* SecureStorageTests.swift in Sources */,
 				2FB77BA52910F84D009FDDE2 /* LocalStorageTests.swift in Sources */,
+				2F1BBE1E2942B62A0054656C /* TestAppUITests.swift in Sources */,
 				2FC2C408291DCC8200712676 /* HealthKitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -38,6 +38,13 @@
          </BuildableReference>
          <BuildableReference
             BuildableIdentifier = "primary"
+            BlueprintIdentifier = "HealthKitDataSource"
+            BuildableName = "HealthKitDataSource"
+            BlueprintName = "HealthKitDataSource"
+            ReferencedContainer = "container:../..">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
             BlueprintIdentifier = "LocalStorage"
             BuildableName = "LocalStorage"
             BlueprintName = "LocalStorage"
@@ -55,13 +62,6 @@
             BlueprintIdentifier = "XCTRuntimeAssertions"
             BuildableName = "XCTRuntimeAssertions"
             BlueprintName = "XCTRuntimeAssertions"
-            ReferencedContainer = "container:../..">
-         </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "HealthKitDataSource"
-            BuildableName = "HealthKitDataSource"
-            BlueprintName = "HealthKitDataSource"
             ReferencedContainer = "container:../..">
          </BuildableReference>
       </CodeCoverageTargets>


### PR DESCRIPTION
# Observable Object Provider

## :recycle: Current situation & Problem
The `ObservableObjectComponent` protocol allows components to provide a single `ObservableObject`. Some components require injecting multiple `ObservableObjects` in the SwiftUI environment.

## :bulb: Proposed solution
The `ObservableObjectProvider` allows developers to define multiple `ObservableObject`s using an ` var observableObjects: [any ObservableObject]` property:
```swift
final class MultipleObservableObjectsTestsComponent<ComponentStandard: Standard>: Module {
    class TestObservableObject<T>: ObservableObject {
        let value: T
        
        
        init(value: T) {
            self.value = value
        }
    }
    
    
    var observableObjects: [any ObservableObject] {
        [
            TestObservableObject(value: 42),
            TestObservableObject(value: "42")
        ]
    }
}
```

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

