### PR TITLE
Add Citation File and DOI to Reference CardinalKit in Publications

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -11,8 +11,8 @@ builder:
   configs:
     - platform: ios
       documentation_targets:
-      - Account
       - CardinalKit
+      - Account
       - Contact
       - FHIR
       - HealthKitDataSource

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the HealthKitOnFHIR open source project
+# This source file is part of the CardinalKit open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Schmiedmayer"
+  given-names: "Paul"
+  orcid: "https://orcid.org/0000-0002-8607-9148"
+- family-names: "Ravi"
+  given-names: "Vishnu"
+  orcid: "https://orcid.org/0000-0003-0359-1275"
+- family-names: "Aalami"
+  given-names: "Oliver"
+  orcid: "https://orcid.org/0000-0002-7799-2429"
+title: "CardinalKit"
+doi: 10.5281/zenodo.7538238
+url: "https://github.com/StanfordBDHG/CardinalKit"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ CardinalKit contributors
 ====================
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
+* [Vishnu Ravi](https://github.com/vishnuravi)

--- a/README.md
+++ b/README.md
@@ -10,10 +10,22 @@ SPDX-License-Identifier: MIT
 
 # CardinalKit
 
+[![Build and Test](https://github.com/StanfordBDHG/CardinalKit/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/StanfordBDHG/CardinalKit/actions/workflows/build-and-test.yml)
+[![codecov](https://codecov.io/gh/StanfordBDHG/CardinalKit/branch/main/graph/badge.svg?token=KHU2K1HTAM)](https://codecov.io/gh/StanfordBDHG/CardinalKit)
+[![DOI](https://zenodo.org/badge/549199889.svg)](https://zenodo.org/badge/latestdoi/549199889)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordBDHG%2FCardinalKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordBDHG/CardinalKit)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordBDHG%2FCardinalKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/StanfordBDHG/CardinalKit)
+
 Open-source framework for rapid development of modern, interoperable digital health applications.
 
+For more information, please refer to the [API documentation](https://swiftpackageindex.com/StanfordBDHG/CardinalKit/documentation).
+
+
 ## Contributing
+
 Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) first.
 
+
 ## License
+
 This project is licensed under the MIT License. See [Licenses](https://github.com/CardinalKit/Template-Repository/tree/develop/LICENSES) for more information.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Contributions to this project are welcome. Please make sure to read the [contrib
 ## License
 
 This project is licensed under the MIT License. See [Licenses](https://github.com/CardinalKit/Template-Repository/tree/develop/LICENSES) for more information.
+
+![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
+![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)


### PR DESCRIPTION
# Add Citation File and DOI to Reference CardinalKit in Publications

## :recycle: Current situation & Problem
The CardinalKit can currently only be references using its URL.

## :bulb: Proposed solution
This PR adds the necessary infrastructure and connections to properly reference the software. It adds a citation File and DOI to Reference CardinalKit in Publications.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
