### PR TITLE
Update Public API and Fix Bugs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "dce2e1abc6c0d5e830ff1cffe3f8633fda64001e",
-        "version" : "10.3.0"
+        "revision" : "0df86ea17d5d281415be74f2290df8431644f156",
+        "version" : "10.4.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "71eb6700dd53a851473c48d392f00a3ab26699a6",
-        "version" : "10.1.0"
+        "revision" : "9a09ece724128e8d1e14c5133b87c0e236844ac0",
+        "version" : "10.4.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "6db6edb48bdd9943426562c7f042a5492de5ba3d",
-        "version" : "7.10.0"
+        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
+        "version" : "7.11.0"
       }
     },
     {

--- a/Sources/CardinalKit/Adapter/SingleValueAdapter.swift
+++ b/Sources/CardinalKit/Adapter/SingleValueAdapter.swift
@@ -14,13 +14,13 @@
 public protocol SingleValueAdapter<InputElement, InputRemovalContext, OutputElement, OutputRemovalContext>: Adapter {
     /// Map the element of the transformed async streams from additions.
     /// - Parameter element: The element that should be transformed.
-    /// - Returns: Returns the transformed element
-    func transform(element: InputElement) -> OutputElement
+    /// - Returns: Returns the transformed element.
+    func transform(element: InputElement) throws -> OutputElement
     
     /// Map the element's removal of the transformed async streams from removals.
     /// - Parameter removalContext: The element's removal context that should be transformed.
     /// - Returns: Returns the transformed removal context.
-    func transform(removalContext: InputRemovalContext) -> OutputRemovalContext
+    func transform(removalContext: InputRemovalContext) throws -> OutputRemovalContext
 }
 
 
@@ -33,9 +33,9 @@ extension SingleValueAdapter {
         asyncSequence.map { [self] element in
             switch element {
             case let .addition(element):
-                return await .addition(transform(element: element))
-            case let .removal(elementId):
-                return await .removal(transform(removalContext: elementId))
+                return await .addition(try transform(element: element))
+            case let .removal(removalContext):
+                return await .removal(try transform(removalContext: removalContext))
             }
         }
     }

--- a/Sources/Contact/Models/Contact.swift
+++ b/Sources/Contact/Models/Contact.swift
@@ -6,16 +6,17 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Contacts
+@_exported import Contacts
 import SwiftUI
+
 
 /// A ``Contact`` encodes the contact information.
 public struct Contact {
     let id = UUID()
-    /// The image of the Contact.
-    public let image: Image?
     /// The name of the individual. Ideally provide at least a first and given name.
     public let name: PersonNameComponents
+    /// The image of the ``Contact``.
+    public let image: Image?
     /// The title of the individual.
     public let title: String?
     /// The desciption of the individual.
@@ -26,6 +27,36 @@ public struct Contact {
     public let address: CNPostalAddress?
     /// The contact options of the individual.
     public let contactOptions: [ContactOption]
+    
+    
+    /// - Parameters:
+    ///   - id: Identiifer of the `Contact` instance.
+    ///   - name: The name of the individual. Ideally provide at least a first and given name.
+    ///   - image: The image of the ``Contact``.
+    ///   - title: The title of the individual.
+    ///   - description: The desciption of the individual.
+    ///   - organization: The organization of the individual.
+    ///   - address: The address of the individual.
+    ///   - contactOptions: The contact options of the individual.
+    public init( // swiftlint:disable:this function_default_parameter_at_end
+        // We want the id to be the first parameter even though it has a default value as it is the primary element identifying a `Contact`.
+        id: UUID = UUID(),
+        name: PersonNameComponents,
+        image: Image? = nil,
+        title: String? = nil,
+        description: String? = nil,
+        organization: String? = nil,
+        address: CNPostalAddress? = nil,
+        contactOptions: [ContactOption] = []
+    ) {
+        self.image = image
+        self.name = name
+        self.title = title
+        self.description = description
+        self.organization = organization
+        self.address = address
+        self.contactOptions = contactOptions
+    }
 }
 
 
@@ -33,8 +64,8 @@ public struct Contact {
 extension Contact {
     static var mock: Contact {
         Contact(
-            image: Image(systemName: "figure.wave.circle"),
             name: PersonNameComponents(givenName: "Paul", familyName: "Schmiedmayer"),
+            image: Image(systemName: "figure.wave.circle"),
             title: "A Title",
             description: """
             This is a description of a contact that will be displayed. It might even be longer than what has to be displayed in the contact card.

--- a/Sources/FHIR/FHIR.swift
+++ b/Sources/FHIR/FHIR.swift
@@ -42,7 +42,7 @@ import XCTRuntimeAssertions
 ///     }
 /// }
 /// ```
-public actor FHIR: Standard {
+public actor FHIR: Standard, ObservableObject, ObservableObjectProvider {
     /// The FHIR `Resource` type builds the `BaseType` of the ``FHIR/FHIR`` standard.
     public typealias BaseType = Resource
     /// The FHIR ``FHIRRemovalContext`` type builds the `RemovalContext` of the ``FHIR/FHIR`` standard.
@@ -65,7 +65,7 @@ public actor FHIR: Standard {
         /// ```swift
         /// let resourceType = ResourceProxy(with: resource).resourceType
         /// ```
-        public let resourceType: String
+        public let resourceType: ResourceType
         
         
         /// - Parameters:
@@ -76,17 +76,21 @@ public actor FHIR: Standard {
         /// ```swift
         /// let resourceType = ResourceProxy(with: resource).resourceType
         /// ```
-        public init(id: BaseType.ID, resourceType: String) {
+        public init(id: BaseType.ID, resourceType: ResourceType) {
             self.id = id
             self.resourceType = resourceType
         }
     }
     
     
+    @Published
     var resources: [String: ResourceProxy] = [:]
     
     @DataStorageProviders
     var dataStorageProviders: [any DataStorageProvider<FHIR>]
+    
+    
+    public init() { }
     
     
     public func registerDataSource(_ asyncSequence: some TypedAsyncSequence<DataChange<BaseType, RemovalContext>>) {

--- a/Sources/FirestoreDataStorage/Firestore.swift
+++ b/Sources/FirestoreDataStorage/Firestore.swift
@@ -67,7 +67,7 @@ public actor Firestore<ComponentStandard: Standard>: Module, DataStorageProvider
     public func process(_ element: DataChange<ComponentStandard.BaseType, ComponentStandard.RemovalContext>) async throws {
         switch element {
         case let .addition(element):
-            let firebaseElement = await adapter.transform(element: element)
+            let firebaseElement = try await adapter.transform(element: element)
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 do {
                     let firestore = FirebaseFirestore.Firestore.firestore()
@@ -86,7 +86,7 @@ public actor Firestore<ComponentStandard: Standard>: Module, DataStorageProvider
                 }
             }
         case let .removal(removalContext):
-            let firebaseRemovalContext = await adapter.transform(removalContext: removalContext)
+            let firebaseRemovalContext = try await adapter.transform(removalContext: removalContext)
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 let firestore = FirebaseFirestore.Firestore.firestore()
                 firestore

--- a/Sources/FirestoreDataStorage/IdentityFirestoreElementAdapter.swift
+++ b/Sources/FirestoreDataStorage/IdentityFirestoreElementAdapter.swift
@@ -52,11 +52,11 @@ public actor DefaultFirestoreElementAdapter<InputElement: FirestoreElement, Inpu
     public init() {}
     
     
-    public func transform(element: InputElement) -> AnyFirestoreElement {
+    public func transform(element: InputElement) throws -> AnyFirestoreElement {
         AnyFirestoreElement(element: element)
     }
     
-    public func transform(removalContext: InputRemovalContext) -> AnyFirestoreRemovalContext {
+    public func transform(removalContext: InputRemovalContext) throws -> AnyFirestoreRemovalContext {
         AnyFirestoreRemovalContext(collectionPath: removalContext.collectionPath, id: removalContext.id)
     }
 }

--- a/Sources/HealthKitDataSource/Adapter/HKSampleRemovalContext.swift
+++ b/Sources/HealthKitDataSource/Adapter/HKSampleRemovalContext.swift
@@ -1,0 +1,22 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+@preconcurrency import HealthKit
+
+
+public struct HKSampleRemovalContext: Identifiable, Sendable {
+    public let id: HKSample.ID
+    public let sampleType: HKSampleType
+    
+    
+    public init(id: HKSample.ID, sampleType: HKSampleType) {
+        self.id = id
+        self.sampleType = sampleType
+    }
+}

--- a/Sources/HealthKitDataSource/CollectSample/HealthKitSampleDataSource.swift
+++ b/Sources/HealthKitDataSource/CollectSample/HealthKitSampleDataSource.swift
@@ -120,7 +120,7 @@ final class HealthKitSampleDataSource<ComponentStandard: Standard, SampleType: H
     }
     
     
-    private func anchoredSingleObjectQuery() -> AsyncThrowingStream<DataChange<HKSample, HKSample.ID>, Error> {
+    private func anchoredSingleObjectQuery() -> AsyncThrowingStream<DataChange<HKSample, HKSampleRemovalContext>, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 let results = try await healthStore.anchoredSingleObjectQuery(

--- a/Sources/HealthKitDataSource/HealthKit.swift
+++ b/Sources/HealthKitDataSource/HealthKit.swift
@@ -51,7 +51,7 @@ import SwiftUI
 /// ```
 public final class HealthKit<ComponentStandard: Standard>: Module {
     /// The ``HealthKit/HKSampleAdapter`` type defines the mapping of `HKSample`s to the component's standard's base type.
-    public typealias HKSampleAdapter = any Adapter<HKSample, HKSample.ID, ComponentStandard.BaseType, ComponentStandard.RemovalContext>
+    public typealias HKSampleAdapter = any Adapter<HKSample, HKSampleRemovalContext, ComponentStandard.BaseType, ComponentStandard.RemovalContext>
     
     
     @StandardActor var standard: ComponentStandard
@@ -116,6 +116,13 @@ public final class HealthKit<ComponentStandard: Standard>: Module {
         
         for healthKitComponent in healthKitComponents {
             healthKitComponent.askedForAuthorization()
+        }
+    }
+    
+    
+    public func willFinishLaunchingWithOptions(_ application: UIApplication, launchOptions: [UIApplication.LaunchOptionsKey: Any]) {
+        for healthKitComponent in healthKitComponents {
+            healthKitComponent.willFinishLaunchingWithOptions(application, launchOptions: launchOptions)
         }
     }
     

--- a/Tests/CardinalKitTests/DataSourceTests/DataSourceTests.swift
+++ b/Tests/CardinalKitTests/DataSourceTests/DataSourceTests.swift
@@ -124,11 +124,11 @@ final class DataSourceTests: XCTestCase {
         typealias OutputRemovalContext = OutputElement.ID
         
         
-        func transform(element: InputElement) -> OutputElement {
+        func transform(element: InputElement) throws -> OutputElement {
             MockStandard.CustomDataSourceType(id: OutputElement.ID(element.id))
         }
         
-        func transform(removalContext: InputRemovalContext) -> OutputRemovalContext {
+        func transform(removalContext: InputRemovalContext) throws -> OutputRemovalContext {
             OutputRemovalContext(removalContext.id)
         }
     }
@@ -140,11 +140,11 @@ final class DataSourceTests: XCTestCase {
         typealias OutputRemovalContext = OutputElement.ID
         
         
-        func transform(element: InputElement) -> OutputElement {
+        func transform(element: InputElement) throws -> OutputElement {
             MockStandard.CustomDataSourceType(id: OutputElement.ID(element.id))
         }
         
-        func transform(removalContext: InputRemovalContext) -> OutputRemovalContext {
+        func transform(removalContext: InputRemovalContext) throws -> OutputRemovalContext {
             OutputRemovalContext(removalContext.id)
         }
     }

--- a/Tests/FHIRTests/FHIRTests.swift
+++ b/Tests/FHIRTests/FHIRTests.swift
@@ -126,8 +126,8 @@ final class DataStorageProviderTests: XCTestCase {
                 continuation.yield(.addition(observation2))
                 continuation.yield(.addition(observation3))
                 continuation.yield(.addition(observationNilId))
-                continuation.yield(.removal(FHIR.RemovalContext(id: nil, resourceType: "Observation")))
-                continuation.yield(.removal(FHIR.RemovalContext(id: "1", resourceType: "Observation")))
+                continuation.yield(.removal(FHIR.RemovalContext(id: nil, resourceType: .observation)))
+                continuation.yield(.removal(FHIR.RemovalContext(id: "1", resourceType: .observation)))
             }
         )
         

--- a/Tests/UITests/TestApp/HealthKitTests/HealthKitTestsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTests/HealthKitTestsView.swift
@@ -30,7 +30,8 @@ struct HealthKitTestsView: View {
                 Text(element)
             }
         }
-            .onAppear {
+            .task {
+                self.dataChanges = await standard.dataChanges.map { $0.id }
                 cancellable = standard.objectWillChange.sink {
                     Task { @MainActor in
                         self.dataChanges = await standard.dataChanges.map { $0.id }

--- a/Tests/UITests/TestApp/Shared/TestAppHealthKitAdapter.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppHealthKitAdapter.swift
@@ -8,20 +8,21 @@
 
 import CardinalKit
 @preconcurrency import HealthKit
+import HealthKitDataSource
 
 
 actor TestAppHealthKitAdapter: SingleValueAdapter {
     typealias InputElement = HKSample
-    typealias InputRemovalContext = UUID
+    typealias InputRemovalContext = HKSampleRemovalContext
     typealias OutputElement = TestAppStandard.BaseType
     typealias OutputRemovalContext = TestAppStandard.RemovalContext
     
     
-    func transform(element: InputElement) -> OutputElement {
+    func transform(element: InputElement) throws -> OutputElement {
         TestAppStandard.BaseType(id: element.sampleType.identifier)
     }
     
-    func transform(removalContext: InputRemovalContext) -> OutputRemovalContext {
-        OutputRemovalContext(id: removalContext.uuidString)
+    func transform(removalContext: InputRemovalContext) throws -> OutputRemovalContext {
+        OutputRemovalContext(id: removalContext.id.uuidString)
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -656,8 +656,8 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -666,10 +666,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -690,8 +693,8 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -700,10 +703,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "dce2e1abc6c0d5e830ff1cffe3f8633fda64001e",
-        "version" : "10.3.0"
+        "revision" : "0df86ea17d5d281415be74f2290df8431644f156",
+        "version" : "10.4.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "71eb6700dd53a851473c48d392f00a3ab26699a6",
-        "version" : "10.1.0"
+        "revision" : "9a09ece724128e8d1e14c5133b87c0e236844ac0",
+        "version" : "10.4.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "6db6edb48bdd9943426562c7f042a5492de5ba3d",
-        "version" : "7.10.0"
+        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
+        "version" : "7.11.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "efda500b6d9858d38a76dbfbfa396bd644692e4a",
-        "version" : "3.0.0"
+        "revision" : "96d7cc73a71ce950723aa3c50ce4fb275ae180b8",
+        "version" : "3.1.0"
       }
     },
     {


### PR DESCRIPTION
# Update Public API and Fix Bugs

## :bulb: Bug Fixes & API Improvements
- The `FHIR` Standard uses the typed `ResourceType` instead of a String value for the removal context.
- The `FHIR` Standard can act as an `ObservableObject`
- The `Contact` type does now have a public initializer
- The `SingleValueAdapter` does allow throwing an error in the transform functions.
- Adds a dedicated `HKSampleRemovalContext` for the HealthKit data source module.
- Fixes a bug in the HealthKit Data Source where data was not immediately loaded after launching the application.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

