### PR TITLE
HealthKitToFHIRAdapter

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "dce2e1abc6c0d5e830ff1cffe3f8633fda64001e",
-        "version" : "10.3.0"
+        "revision" : "0df86ea17d5d281415be74f2290df8431644f156",
+        "version" : "10.4.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "71eb6700dd53a851473c48d392f00a3ab26699a6",
-        "version" : "10.1.0"
+        "revision" : "9a09ece724128e8d1e14c5133b87c0e236844ac0",
+        "version" : "10.4.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "6db6edb48bdd9943426562c7f042a5492de5ba3d",
-        "version" : "7.10.0"
+        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
+        "version" : "7.11.0"
       }
     },
     {
@@ -79,6 +79,15 @@
       "state" : {
         "revision" : "96d7cc73a71ce950723aa3c50ce4fb275ae180b8",
         "version" : "3.1.0"
+      }
+    },
+    {
+      "identity" : "healthkitonfhir",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR",
+      "state" : {
+        "revision" : "af1baa6950fb54fb81f44496f088349df0f6e55d",
+        "version" : "0.2.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR",
       "state" : {
-        "revision" : "af1baa6950fb54fb81f44496f088349df0f6e55d",
-        "version" : "0.2.1"
+        "revision" : "1b7b7d71c30563f84d4c892421caf7f1c79ff09e",
+        "version" : "0.2.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
         .library(name: "FHIR", targets: ["FHIR"]),
         .library(name: "FirestoreDataStorage", targets: ["FirestoreDataStorage"]),
         .library(name: "HealthKitDataSource", targets: ["HealthKitDataSource"]),
+        .library(name: "HealthKitToFHIRAdapter", targets: ["HealthKitToFHIRAdapter"]),
         .library(name: "LocalStorage", targets: ["LocalStorage"]),
         .library(name: "Onboarding", targets: ["Onboarding"]),
         .library(name: "Scheduler", targets: ["Scheduler"]),
@@ -33,7 +34,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.4.0")),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.3.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.3.0"),
+        .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.1"))
     ],
     targets: [
         .target(
@@ -94,6 +96,16 @@ let package = Package(
             name: "HealthKitDataSource",
             dependencies: [
                 .target(name: "CardinalKit")
+            ]
+        ),
+        .target(
+            name: "HealthKitToFHIRAdapter",
+            dependencies: [
+                .target(name: "CardinalKit"),
+                .target(name: "FHIR"),
+                .target(name: "HealthKitDataSource"),
+                .product(name: "ModelsR4", package: "FHIRModels"),
+                .product(name: "HealthKitOnFHIR", package: "HealthKitOnFHIR")
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.4.0")),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.3.0"),
-        .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.1"))
+        .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.2"))
     ],
     targets: [
         .target(

--- a/Sources/HealthKitToFHIRAdapter/HealthKitToFHIRAdapter.swift
+++ b/Sources/HealthKitToFHIRAdapter/HealthKitToFHIRAdapter.swift
@@ -1,0 +1,38 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import FHIR
+import HealthKit
+import HealthKitDataSource
+import HealthKitOnFHIR
+
+
+public actor HealthKitToFHIRAdapter: SingleValueAdapter {
+    public typealias InputElement = HKSample
+    public typealias InputRemovalContext = HKSampleRemovalContext
+    public typealias OutputElement = FHIR.BaseType
+    public typealias OutputRemovalContext = FHIR.RemovalContext
+    
+    
+    public init() {}
+    
+    
+    public func transform(element: InputElement) throws -> OutputElement {
+        let resource = try element.resource.get()
+        resource.id = element.id.uuidString.asFHIRStringPrimitive()
+        return resource
+    }
+    
+    public func transform(removalContext: InputRemovalContext) throws -> OutputRemovalContext {
+        OutputRemovalContext(
+            id: removalContext.id.uuidString.asFHIRStringPrimitive(),
+            resourceType: try removalContext.sampleType.resourceTyoe
+        )
+    }
+}

--- a/Sources/HealthKitToFHIRAdapter/HealthKitToFHIRAdapter.swift
+++ b/Sources/HealthKitToFHIRAdapter/HealthKitToFHIRAdapter.swift
@@ -24,9 +24,7 @@ public actor HealthKitToFHIRAdapter: SingleValueAdapter {
     
     
     public func transform(element: InputElement) throws -> OutputElement {
-        let resource = try element.resource.get()
-        resource.id = element.id.uuidString.asFHIRStringPrimitive()
-        return resource
+        try element.resource.get()
     }
     
     public func transform(removalContext: InputRemovalContext) throws -> OutputRemovalContext {


### PR DESCRIPTION
# HealthKitToFHIRAdapter

## :recycle: Current situation & Problem
- The FHIR standard requires that health data including samples from HealthKit can be transformed into a FHIR representation.

## :bulb: Proposed solution
- This PR adds the `HealthKitToFHIRAdapter` that builds on top of [HealthKitOnFHIR](https://github.com/StanfordBDHG/HealthKitOnFHIR) to enable a mapping of HealthKit samples to FHIR resources.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

