### PR TITLE
FHIRToFirestoreAdapter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .library(name: "CardinalKit", targets: ["CardinalKit"]),
         .library(name: "Contact", targets: ["Contact"]),
         .library(name: "FHIR", targets: ["FHIR"]),
+        .library(name: "FHIRToFirestoreAdapter", targets: ["FHIRToFirestoreAdapter"]),
         .library(name: "FirestoreDataStorage", targets: ["FirestoreDataStorage"]),
         .library(name: "HealthKitDataSource", targets: ["HealthKitDataSource"]),
         .library(name: "HealthKitToFHIRAdapter", targets: ["HealthKitToFHIRAdapter"]),
@@ -85,6 +86,14 @@ let package = Package(
             name: "FHIRTests",
             dependencies: [
                 .target(name: "FHIR")
+            ]
+        ),
+        .target(
+            name: "FHIRToFirestoreAdapter",
+            dependencies: [
+                .target(name: "CardinalKit"),
+                .target(name: "FHIR"),
+                .target(name: "FirestoreDataStorage")
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -96,6 +96,14 @@ let package = Package(
                 .target(name: "FirestoreDataStorage")
             ]
         ),
+        .testTarget(
+            name: "FHIRToFirestoreAdapterTests",
+            dependencies: [
+                .target(name: "FHIRToFirestoreAdapter"),
+                .target(name: "FHIR"),
+                .product(name: "ModelsR4", package: "FHIRModels")
+            ]
+        ),
         .target(
             name: "FirestoreDataStorage",
             dependencies: [

--- a/Sources/FHIRToFirestoreAdapter/FHIRFirestoreElement.swift
+++ b/Sources/FHIRToFirestoreAdapter/FHIRFirestoreElement.swift
@@ -1,0 +1,33 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import FHIR
+import FirestoreDataStorage
+import Foundation
+
+
+/// Provides a mapping from a FHIR `Resource` to a type conforming to `FirestoreElement`.
+public struct FHIRFirestoreElement: FirestoreElement, @unchecked Sendable {
+    let resource: Resource
+    
+    public let id: String
+    public let collectionPath: String
+    
+    
+    init(_ baseType: FHIR.BaseType) {
+        self.resource = baseType
+        self.id = baseType.id?.value?.string ?? UUID().uuidString
+        self.collectionPath = ResourceProxy(with: baseType).resourceType
+    }
+    
+    
+    public func encode(to encoder: Encoder) throws {
+        try resource.encode(to: encoder)
+    }
+}

--- a/Sources/FHIRToFirestoreAdapter/FHIRFirestoreRemovalContext.swift
+++ b/Sources/FHIRToFirestoreAdapter/FHIRFirestoreRemovalContext.swift
@@ -1,0 +1,25 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import FHIR
+import FirestoreDataStorage
+import Foundation
+
+
+/// Provides a mapping from a FHIR standard `RemovalContext` to a type conforming to `FHIRFirestoreRemovalContext`.
+public struct FHIRFirestoreRemovalContext: FirestoreRemovalContext, @unchecked Sendable {
+    public let id: String
+    public let collectionPath: String
+    
+    
+    init(_ removalContext: FHIR.RemovalContext) {
+        self.id = removalContext.id?.value?.string ?? UUID().uuidString
+        self.collectionPath = removalContext.resourceType.rawValue
+    }
+}

--- a/Sources/FHIRToFirestoreAdapter/FHIRToFirestoreAdapter.docc/FHIRToFirestoreAdapter.md
+++ b/Sources/FHIRToFirestoreAdapter/FHIRToFirestoreAdapter.docc/FHIRToFirestoreAdapter.md
@@ -1,0 +1,30 @@
+# ``FHIRToFirestoreAdapter``
+
+<!--
+                  
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+             
+-->
+
+Adapts the output of the `FHIR` standard to be used with the `Firestore` data storage provider.
+
+## Overview
+
+Use the ``FHIRToFirestoreAdapter`` in the adapter result builder of the `Firestore` data storage provider in the CardinalKit `Configuration`.
+
+```swift
+class ExampleAppDelegate: CardinalKitAppDelegate {
+    override var configuration: Configuration {
+        Configuration(standard: FHIR()) {
+            Firestore {
+                FHIRToFirestoreAdapter()
+            }
+            // ...
+        }
+    }
+}
+```

--- a/Sources/FHIRToFirestoreAdapter/FHIRToFirestoreAdapter.swift
+++ b/Sources/FHIRToFirestoreAdapter/FHIRToFirestoreAdapter.swift
@@ -8,45 +8,23 @@
 
 import CardinalKit
 import FHIR
-import FirestoreDataStorage
-import Foundation
 
 
-/// <#Description#>
-public struct FHIRFirestoreElement: FirestoreElement, @unchecked Sendable {
-    let resource: Resource
-    
-    public let id: String
-    public let collectionPath: String
-    
-    
-    init(_ baseType: FHIR.BaseType) {
-        self.resource = baseType
-        self.id = baseType.id?.value?.string ?? UUID().uuidString
-        self.collectionPath = ResourceProxy(with: baseType).resourceType
-    }
-    
-    
-    public func encode(to encoder: Encoder) throws {
-        try resource.encode(to: encoder)
-    }
-}
-
-
-/// <#Description#>
-public struct FHIRFirestoreRemovalContext: FirestoreRemovalContext, @unchecked Sendable {
-    public let id: String
-    public let collectionPath: String
-    
-    
-    init(_ removalContext: FHIR.RemovalContext) {
-        self.id = removalContext.id?.value?.string ?? UUID().uuidString
-        self.collectionPath = removalContext.resourceType.rawValue
-    }
-}
-
-
-/// <#Description#>
+/// Adapts the output of the `FHIR` standard to be used with the `Firestore` data storage provider.
+///
+/// Use the ``FHIRToFirestoreAdapter`` in the adapter result builder of the `Firestore` data storage provider in the CardinalKit `Configuration`.
+/// ```swift
+/// class ExampleAppDelegate: CardinalKitAppDelegate {
+///     override var configuration: Configuration {
+///         Configuration(standard: FHIR()) {
+///             Firestore {
+///                 FHIRToFirestoreAdapter()
+///             }
+///             // ...
+///         }
+///     }
+/// }
+/// ```
 public actor FHIRToFirestoreAdapter: SingleValueAdapter {
     public typealias InputElement = FHIR.BaseType
     public typealias InputRemovalContext = FHIR.RemovalContext

--- a/Sources/FHIRToFirestoreAdapter/FHIRToFirestoreAdapter.swift
+++ b/Sources/FHIRToFirestoreAdapter/FHIRToFirestoreAdapter.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import FHIR
+import FirestoreDataStorage
+import Foundation
+
+
+/// <#Description#>
+public struct FHIRFirestoreElement: FirestoreElement, @unchecked Sendable {
+    let resource: Resource
+    
+    public let id: String
+    public let collectionPath: String
+    
+    
+    init(_ baseType: FHIR.BaseType) {
+        self.resource = baseType
+        self.id = baseType.id?.value?.string ?? UUID().uuidString
+        self.collectionPath = ResourceProxy(with: baseType).resourceType
+    }
+    
+    
+    public func encode(to encoder: Encoder) throws {
+        try resource.encode(to: encoder)
+    }
+}
+
+
+/// <#Description#>
+public struct FHIRFirestoreRemovalContext: FirestoreRemovalContext, @unchecked Sendable {
+    public let id: String
+    public let collectionPath: String
+    
+    
+    init(_ removalContext: FHIR.RemovalContext) {
+        self.id = removalContext.id?.value?.string ?? UUID().uuidString
+        self.collectionPath = removalContext.resourceType.rawValue
+    }
+}
+
+
+/// <#Description#>
+public actor FHIRToFirestoreAdapter: SingleValueAdapter {
+    public typealias InputElement = FHIR.BaseType
+    public typealias InputRemovalContext = FHIR.RemovalContext
+    public typealias OutputElement = FHIRFirestoreElement
+    public typealias OutputRemovalContext = FHIRFirestoreRemovalContext
+    
+    
+    public init() {}
+    
+    
+    public func transform(element: InputElement) throws -> FHIRFirestoreElement {
+        FHIRFirestoreElement(element)
+    }
+    
+    public func transform(removalContext: InputRemovalContext) throws -> FHIRFirestoreRemovalContext {
+        FHIRFirestoreRemovalContext(removalContext)
+    }
+}

--- a/Tests/FHIRToFirestoreAdapterTests/FHIRToFirestoreAdapterTests.swift
+++ b/Tests/FHIRToFirestoreAdapterTests/FHIRToFirestoreAdapterTests.swift
@@ -1,0 +1,41 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import FHIR
+import FHIRToFirestoreAdapter
+import ModelsR4
+import XCTest
+
+
+final class FHIRToFirestoreAdapterTests: XCTestCase {
+    func testHealthKitToFHIRAdapterTransformElement() async throws {
+        let adapter = FHIRToFirestoreAdapter()
+        
+        let observation = Observation(
+            code: CodeableConcept(),
+            id: "1",
+            status: FHIRPrimitive<ObservationStatus>(.final)
+        )
+        
+        let mappedElement = try await adapter.transform(element: observation)
+        
+        XCTAssert(mappedElement.id == "1")
+        XCTAssert(mappedElement.collectionPath == "Observation")
+    }
+    
+    func testHealthKitToFHIRAdapterTransformReuseContext() async throws {
+        let adapter = FHIRToFirestoreAdapter()
+        
+        let removalContext = FHIR.RemovalContext(id: "1", resourceType: .observation)
+        
+        let mappedRemovalContext = try await adapter.transform(removalContext: removalContext)
+        
+        XCTAssert(mappedRemovalContext.id == "1")
+        XCTAssert(mappedRemovalContext.collectionPath == "Observation")
+    }
+}

--- a/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
+++ b/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
@@ -9,70 +9,14 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : {
-      "targets" : [
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "Account",
-          "name" : "Account"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "CardinalKit",
-          "name" : "CardinalKit"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "Contact",
-          "name" : "Contact"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "FHIR",
-          "name" : "FHIR"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "HealthKitDataSource",
-          "name" : "HealthKitDataSource"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "LocalStorage",
-          "name" : "LocalStorage"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "Onboarding",
-          "name" : "Onboarding"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "SecureStorage",
-          "name" : "SecureStorage"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "Views",
-          "name" : "Views"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "XCTRuntimeAssertions",
-          "name" : "XCTRuntimeAssertions"
-        },
-        {
-          "containerPath" : "container:..\/..",
-          "identifier" : "Scheduler",
-          "name" : "Scheduler"
-        }
-      ]
-    },
+    "maximumTestRepetitions" : 2,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:UITests.xcodeproj",
       "identifier" : "2F6D139128F5F384007C25D6",
       "name" : "TestApp"
-    }
+    },
+    "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [
     {


### PR DESCRIPTION
# FHIRToFirestoreAdapter

## :recycle: Current situation & Problem
The Firestore Data Storage component currently can not be connected with the FHIR standard.

## :bulb: Proposed solution
The `FHIRToFirestoreAdapter` takes advantage of the similarities between the requirements to map a FHIR `Resource` and FHIR standard `RemovalContext` to a type conforming to `FirestoreElement` and `FirestoreRemovalContext`.

## :gear: Release Notes 
- Adds a `FHIRToFirestoreAdapter` to connect the `FHIR` standard to the `FirestoreDataStorage` module.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).