### PR TITLE
Add Documentation for the Main CardinalKit Module

### DIFF
--- a/Sources/Account/Username and Password/Login/UsernamePasswordLoginView.swift
+++ b/Sources/Account/Username and Password/Login/UsernamePasswordLoginView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// Applications must ensure that an ``UsernamePasswordAccountService`` instance is injected in the SwiftUI environment by, e.g., using the `.environmentObject(_:)` view modifier.
 ///
 /// The view can automatically validate input using passed in ``ValidationRule``s and can be customized using header or footer views:
-/// ```
+/// ```swift
 /// UsernamePasswordLoginView(
 ///     passwordValidationRules: [
 ///         /* ... */

--- a/Sources/Account/Username and Password/ResetPassword/UsernamePasswordResetPasswordView.swift
+++ b/Sources/Account/Username and Password/ResetPassword/UsernamePasswordResetPasswordView.swift
@@ -19,7 +19,7 @@ import Views
 /// Applications must ensure that an ``UsernamePasswordAccountService`` instance is injected in the SwiftUI environment by, e.g., using the `.environmentObject(_:)` view modifier.
 ///
 /// The view can automatically validate input using passed in ``ValidationRule``s and can be customized using header or footer views:
-/// ```
+/// ```swift
 /// UsernamePasswordResetPasswordView(
 ///     usernameValidationRules: [
 ///         /* ... */
@@ -35,7 +35,7 @@ import Views
 ///     }
 /// )
 ///     .environmentObject(UsernamePasswordAccountService())
-/// ``
+/// ```
 public struct UsernamePasswordResetPasswordView: View {
     private let usernameValidationRules: [ValidationRule]
     private let header: AnyView

--- a/Sources/Account/Username and Password/Shared/ValidationRule.swift
+++ b/Sources/Account/Username and Password/Shared/ValidationRule.swift
@@ -10,7 +10,7 @@
 /// A rule used for validating text along with a message to display if the validation fails.
 ///
 /// The following example demonstrates a ``ValidationRule`` using a regex expression for an email.
-/// ```
+/// ```swift
 /// ValidationRule(
 ///     regex: try? Regex("[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"),
 ///     message: "The entered email is not correct."

--- a/Sources/Account/Username and Password/Sign Up/UsernamePasswordSignUpView.swift
+++ b/Sources/Account/Username and Password/Sign Up/UsernamePasswordSignUpView.swift
@@ -21,7 +21,7 @@ import Views
 /// Applications must ensure that an ``UsernamePasswordAccountService`` instance is injected in the SwiftUI environment by, e.g., using the `.environmentObject(_:)` view modifier.
 ///
 /// The view can automatically validate input using passed in ``ValidationRule``s and can be customized using header or footer views:
-/// ```
+/// ```swift
 /// UsernamePasswordSignUpView(
 ///     passwordValidationRules: [
 ///         /* ... */

--- a/Sources/CardinalKit/Adapter/Adapter.swift
+++ b/Sources/CardinalKit/Adapter/Adapter.swift
@@ -80,28 +80,3 @@ public protocol Adapter<InputElement, InputRemovalContext, OutputElement, Output
         _ asyncSequence: some TypedAsyncSequence<DataChange<InputElement, InputRemovalContext>>
     ) async -> any TypedAsyncSequence<DataChange<OutputElement, OutputRemovalContext>>
 }
-
-actor ExampleStandard: Standard {
-    func registerDataSource(_ asyncSequence: some TypedAsyncSequence<DataChange<BaseType, RemovalContext>>) {
-        fatalError()
-    }
-    
-    typealias BaseType = String
-    typealias RemovalContext = String
-}
-
-final class DataSourceExample<T: Identifiable>: Component {
-    typealias ComponentStandard = ExampleStandard
-    typealias DataSourceExampleAdapter = Adapter<T, T.ID, ExampleStandard.BaseType, ExampleStandard.RemovalContext>
-    
-    @StandardActor var standard: ExampleStandard
-    let adapter: any DataSourceExampleAdapter
-    
-    
-    init(@AdapterBuilder<ExampleStandard.BaseType, ExampleStandard.RemovalContext> adapter: () -> (any DataSourceExampleAdapter)) {
-        self.adapter = adapter()
-    }
-    
-    
-    // ...
-}

--- a/Sources/CardinalKit/Adapter/Adapter.swift
+++ b/Sources/CardinalKit/Adapter/Adapter.swift
@@ -10,7 +10,55 @@
 /// A ``Adapter`` can be used to transfrom an input `DataChange` (`InputElement` and `InputRemovalContext`)
 /// to an output `DataChange` (`OutputElement` and `OutputRemovalContext`).
 ///
-/// Use the ``AdapterBuilder`` to offer developers to option to pass in a `Adapter` instance to your components.
+///
+/// The following example demonstrates a simple ``Adapter`` that transforms an `Int` to a `String` (both have been extended to conform to `Identifiable`).
+/// The mapping function uses the ``DataChange/map(element:removalContext:)`` function.
+/// ```swift
+/// actor IntToStringAdapter: Adapter {
+///     typealias InputElement = Int
+///     typealias InputRemovalContext = InputElement.ID
+///     typealias OutputElement = String
+///     typealias OutputRemovalContext = OutputElement.ID
+///
+///
+///     func transform(
+///         _ asyncSequence: some TypedAsyncSequence<DataChange<InputElement, InputRemovalContext>>
+///     ) async -> any TypedAsyncSequence<DataChange<OutputElement, OutputRemovalContext>> {
+///         asyncSequence.map { element in
+///             element.map(
+///                 element: {
+///                     String($0.id)
+///                 },
+///                 removalContext: {
+///                     String($0.id)
+///                 }
+///             )
+///         }
+///     }
+/// }
+/// ```
+///
+/// The ``SingleValueAdapter`` provides a even more convenient way to implement adapters if the transformation can be done on a item-by-item basis.
+///
+/// Use the ``AdapterBuilder`` to offer developers to option to pass in a `Adapter` instance to your components:
+/// ```swift
+/// final class DataSourceExample<T: Identifiable>: Component {
+///     typealias ComponentStandard = ExampleStandard
+///     typealias DataSourceExampleAdapter = Adapter<T, T.ID, ExampleStandard.BaseType, ExampleStandard.RemovalContext>
+///
+///
+///     @StandardActor var standard: ExampleStandard
+///     let adapter: any DataSourceExampleAdapter
+///
+///
+///     init(@AdapterBuilder<ExampleStandard.BaseType, ExampleStandard.RemovalContext> adapter: () -> (any DataSourceExampleAdapter)) {
+///         self.adapter = adapter()
+///     }
+///
+///
+///     // ...
+/// }
+/// ```
 public protocol Adapter<InputElement, InputRemovalContext, OutputElement, OutputRemovalContext>: Actor {
     /// The input element of the ``Adapter``
     associatedtype InputElement: Identifiable, Sendable where InputElement.ID: Sendable
@@ -31,4 +79,29 @@ public protocol Adapter<InputElement, InputRemovalContext, OutputElement, Output
     func transform(
         _ asyncSequence: some TypedAsyncSequence<DataChange<InputElement, InputRemovalContext>>
     ) async -> any TypedAsyncSequence<DataChange<OutputElement, OutputRemovalContext>>
+}
+
+actor ExampleStandard: Standard {
+    func registerDataSource(_ asyncSequence: some TypedAsyncSequence<DataChange<BaseType, RemovalContext>>) {
+        fatalError()
+    }
+    
+    typealias BaseType = String
+    typealias RemovalContext = String
+}
+
+final class DataSourceExample<T: Identifiable>: Component {
+    typealias ComponentStandard = ExampleStandard
+    typealias DataSourceExampleAdapter = Adapter<T, T.ID, ExampleStandard.BaseType, ExampleStandard.RemovalContext>
+    
+    @StandardActor var standard: ExampleStandard
+    let adapter: any DataSourceExampleAdapter
+    
+    
+    init(@AdapterBuilder<ExampleStandard.BaseType, ExampleStandard.RemovalContext> adapter: () -> (any DataSourceExampleAdapter)) {
+        self.adapter = adapter()
+    }
+    
+    
+    // ...
 }

--- a/Sources/CardinalKit/Adapter/AdapterBuilder.swift
+++ b/Sources/CardinalKit/Adapter/AdapterBuilder.swift
@@ -84,6 +84,26 @@ private actor ThreeAdapterChain<
 
 
 /// A function builder used to generate data source registry adapter chains.
+///
+/// Use the ``AdapterBuilder`` to offer developers to option to pass in a `Adapter` instance to your components:
+/// ```swift
+/// final class DataSourceExample<T: Identifiable>: Component {
+///     typealias ComponentStandard = ExampleStandard
+///     typealias DataSourceExampleAdapter = Adapter<T, T.ID, ExampleStandard.BaseType, ExampleStandard.RemovalContext>
+///
+///
+///     @StandardActor var standard: ExampleStandard
+///     let adapter: any DataSourceExampleAdapter
+///
+///
+///     init(@AdapterBuilder<ExampleStandard.BaseType, ExampleStandard.RemovalContext> adapter: () -> (any DataSourceExampleAdapter)) {
+///         self.adapter = adapter()
+///     }
+///
+///
+///     // ...
+/// }
+/// ```
 @resultBuilder
 public enum AdapterBuilder<OutputElement: Identifiable & Sendable, OutputRemovalContext: Identifiable & Sendable> where OutputElement.ID: Sendable, OutputElement.ID == OutputRemovalContext.ID {
     /// Required by every result builder to build combined results from statement blocks.

--- a/Sources/CardinalKit/Adapter/DataChange.swift
+++ b/Sources/CardinalKit/Adapter/DataChange.swift
@@ -7,7 +7,22 @@
 //
 
 
-/// A ``DataChange`` tracks the addition or removel of elements across components.
+/// A ``DataChange`` tracks the addition or removal of elements across components.
+///
+/// ``DataChange`` instances are used in ``DataSourceRegistry``s to identify incoming data. ``Adapter``s use them as the basis for the transform functions.
+///
+/// The ``DataChange/map(element:removalContext:)`` function provides a convenient way to transform one ``DataChange`` instance in an other ``DataChange`` instance:
+/// ```swift
+/// let element: DataChange<Int, Int> = .addition(42)
+/// element.map(
+///     element: {
+///         String($0.id)
+///     },
+///     removalContext: {
+///         String($0.id)
+///     }
+/// )
+/// ```
 public enum DataChange<
     Element: Identifiable & Sendable,
     RemovalContext: Identifiable & Sendable

--- a/Sources/CardinalKit/Adapter/SingleValueAdapter.swift
+++ b/Sources/CardinalKit/Adapter/SingleValueAdapter.swift
@@ -10,6 +10,53 @@
 /// A ``SingleValueAdapter`` is a ``Adapter`` that can be used to more simply transform data using the
 /// ``SingleValueAdapter/transform(element:)`` and ``SingleValueAdapter/transform(removalContext:)`` functions.
 ///
+/// The following example demonstrates a simple ``Adapter`` that transforms an `Int` to a `String` (both have been extended to conform to `Identifiable`).
+/// The mapping function uses the ``DataChange/map(element:removalContext:)`` function.
+/// ```swift
+/// actor IntToStringAdapter: Adapter {
+///     typealias InputElement = Int
+///     typealias InputRemovalContext = InputElement.ID
+///     typealias OutputElement = String
+///     typealias OutputRemovalContext = OutputElement.ID
+///
+///
+///     func transform(
+///         _ asyncSequence: some TypedAsyncSequence<DataChange<InputElement, InputRemovalContext>>
+///     ) async -> any TypedAsyncSequence<DataChange<OutputElement, OutputRemovalContext>> {
+///         asyncSequence.map { element in
+///             element.map(
+///                 element: {
+///                     String($0.id)
+///                 },
+///                 removalContext: {
+///                     String($0.id)
+///                 }
+///             )
+///         }
+///     }
+/// }
+/// ```
+///
+/// The `IntToStringAdapter` can be transformed to a ``SingleValueAdapter`` by breaking up the
+/// functionality in the ``SingleValueAdapter/transform(element:)`` and ``SingleValueAdapter/transform(removalContext:)`` methods:
+/// ```swift
+/// actor IntToStringSingleValueAdapter: SingleValueAdapter {
+///     typealias InputElement = Int
+///     typealias InputRemovalContext = InputElement.ID
+///     typealias OutputElement = String
+///     typealias OutputRemovalContext = OutputElement.ID
+///
+///
+///     func transform(element: Int) throws -> String {
+///         String(element)
+///     }
+///
+///     func transform(removalContext: InputElement.ID) throws -> OutputElement.ID {
+///         String(removalContext)
+///     }
+/// }
+/// ```
+///
 /// See ``Adapter`` for more detail about data source registry adapters.
 public protocol SingleValueAdapter<InputElement, InputRemovalContext, OutputElement, OutputRemovalContext>: Adapter {
     /// Map the element of the transformed async streams from additions.

--- a/Sources/CardinalKit/CardinalKit.docc/CardinalKit.md
+++ b/Sources/CardinalKit/CardinalKit.docc/CardinalKit.md
@@ -14,21 +14,33 @@ Open-source framework for rapid development of modern, interoperable digital hea
 
 ## Overview
 
-This is an example for a DocC documentation for the CardinalKit package.
+> Note: Refer to the <doc:Setup> instructions on how to integrate CardinalKit into your application!
 
+CardinalKit introduces a standards-based modular approach to building digital health applications. A standard builds the shared repository of data mapped to a common understanding that is used to exchange data between CardinalKit modules.
+
+We differentiate between five different types of modules:
+- **Standard**: Acts as a shared repository and common ground of communication between modules. We, e.g., provide the FHIR standard as a great standard to build your digital health applications.
+- **Data Sources**: Provide input to a standard and utilize the standard's data source registration functionality and adapters to transform data into the standardized format. Examples include the HealthKit data source.
+- **Data Source User Interfaces**: Data source user interfaces are data sources that also present user interface components. This, e.g., includes the questionnaire module in the CardinalKit Swift Package.
+- **Data Storage Providers**: Data storage providers obtain elements from a standard and persistently store them. Examples include uploading the data to a cloud storage provider such as the Firebase module.
+- **Research Application User Interface**: Research application user interfaces display additional context in the application and include the onboarding, consent, and contacts modules to display great digital health applications.
+
+![System Architecture of the CardinalKit Framework](SystemArchitecture)
+
+> Note: CardinalKit relies on an ecosystem of modules. Think about what modules you want to build and contribute to the open-source community! Refer to <doc:ModuleCapabilities> to learn more about building your modules.
 
 ## Topics
 
 ### CardinalKit Setup
 
+- <doc:Setup>
 - ``CardinalKit/CardinalKit``
 - ``CardinalKitAppDelegate``
 - ``Standard``
 
 ### Modules
 
-You can learn more about module capabilites at ...
-
+- <doc:ModuleCapabilities>
 - ``Module``
 
 ### Data Sources

--- a/Sources/CardinalKit/CardinalKit.docc/ModuleCapabilities.md
+++ b/Sources/CardinalKit/CardinalKit.docc/ModuleCapabilities.md
@@ -10,14 +10,116 @@ SPDX-License-Identifier: MIT
              
 -->
 
-<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+Building a module provides an easy one-stop solution to support different CardinalKit components and provide this functionality to the CardinalKit ecosystem.
 
-## Overview
+## Components
 
-<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+A ``Component`` defines a software subsystem that can be configured as part of the ``CardinalKitAppDelegate/configuration``.
+
+The ``Component/ComponentStandard`` defines what Standard the component supports.
+The ``Component/configure()-m7ic`` method is called on the initialization of CardinalKit.
+
+### The Component Standard
+
+A ``Component`` can support any generic standard or add additional constraints using an optional where clause:
+```swift
+class ExampleComponent<ComponentStandard: Standard>: Component where ComponentStandard: /* ... */ {
+    /*... */
+}
+```
+
+``Component``s can also specify support for only one specific ``Standard`` using a `typealias` definition:
+```swift
+class ExampleFHIRComponent: Component {
+    typealias ComponentStandard = FHIR
+}
+```
+
+> Note: You can learn more about a ``Standard`` in the ``Standard`` docmentation.
+
+### Dependencies
+
+A ``Component`` can define the dependencies using the @``Component/Dependency`` property wrapper:
+```swift
+class ExampleComponent<ComponentStandard: Standard>: Component {
+    @Dependency var exampleComponentDependency = ExampleComponentDependency()
+}
+```
+
+Some components do not need a default value assigned to the property if they provide a default configuration and conform to ``DefaultInitializable``.
+```swift
+class ExampleComponent<ComponentStandard: Standard>: Component {
+    @Dependency var exampleComponentDependency: ExampleComponentDependency
+}
+```
+
+You can access the wrapped value of the ``Component/Dependency`` after the ``Component`` is configured using ``Component/configure()-5lup3``,
+e.g. in the ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)-26h4k`` function.
+
+> Note: You can learn more about a ``Component/Dependency`` in the ``Component/Dependency`` docmentation. You can also dynamically define dependencies using the ``Component/DynamicDependencies`` property wrapper.
+
+
+## Component Capabilities
+
+Components can also conform to different additional protocols to provide additional access to CardinalKit features.
+- ``LifecycleHandler``: Delegate methods are related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
+- ``ObservableObjectProvider``: A ``Component`` can conform to ``ObservableObjectProvider`` to inject `ObservableObject`s in the SwiftUI view hierarchy.
+
+### LifecycleHandler
+
+The ``LifecycleHandler`` delegate methods are related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
+
+Conform to the `LifecycleHandler` protocol to get updates about the application lifecycle similar to the `UIApplicationDelegate` on an app basis.
+
+You can, e.g., implement the following functions to get informed about the application launching and being terminated:
+- ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)-26h4k``
+- ``LifecycleHandler/applicationWillTerminate(_:)-8wh06``
+
+### ObservableObjectProvider
+
+A ``Component`` can conform to ``ObservableObjectProvider`` to inject `ObservableObject`s in the SwiftUI view hierarchy using ``ObservableObjectProvider/observableObjects-6w1nz``
+
+
+Reference types conforming to `ObservableObject` can be used in SwiftUI views to inform a view about changes in the object.
+You can create and use them in a view using `@ObservedObject` or get it from the SwiftUI environment using `@EnvironmentObject`.
+
+A Component can conform to `ObservableObjectProvider` to inject `ObservableObject`s in the SwiftUI view hierarchy.
+You define all `ObservableObject`s that should be injected using the ``ObservableObjectProvider/observableObjects-5nl18`` property.
+```swift
+class MyComponent<ComponentStandard: Standard>: ObservableObjectProvider {
+    public var observableObjects: [any ObservableObject] {
+        [/* ... */]
+    }
+}
+```
+
+`ObservableObjectProvider` provides a default implementation of the ``ObservableObjectProvider/observableObjects-5nl18`` If your type conforms to `ObservableObject`
+that just injects itself into the SwiftUI view hierarchy:
+```swift
+class MyComponent<ComponentStandard: Standard>: ObservableObject, ObservableObjectProvider {
+    @Published
+    var test: String
+
+    // ...
+}
+```
+
+
+## Modules
+
+All these component capabilities are combined in the ``Module`` protocol, making it an easy one-stop solution to support all these different functionalities and build a capable CardinalKit module.
+
+A ``Module`` is a ``Component`` that also includes
+- Conformance to a ``LifecycleHandler``
+- Persistance in the ``CardinalKit`` instance's ``CardinalKit/CardinalKit/typedCollection`` (using a conformance to ``TypedCollectionKey``)
+- Automatic injection in the SwiftUI view hierachy (``ObservableObjectProvider`` & `ObservableObject`)
+
 
 ## Topics
 
-### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+### Modules & Component Capabilities
 
-- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
+- ``Component``
+- ``Module``
+- ``LifecycleHandler``
+- ``ObservableObjectProvider``

--- a/Sources/CardinalKit/CardinalKit.docc/Setup.md
+++ b/Sources/CardinalKit/CardinalKit.docc/Setup.md
@@ -10,11 +10,75 @@ SPDX-License-Identifier: MIT
              
 -->
 
-<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+The CardinalKit framework can be integrated into any iOS application. You can define which modules you want to integrate into the CardinalKit configuration.
 
-## Overview
+## 1. Add the CardinalKit View Modifier
 
-<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+Set up the CardinalKit framework in your `App` instance of your SwiftUI application using the ``CardinalKitAppDelegate`` and the `@UIApplicationDelegateAdaptor` property wrapper.
+Use the `View.cardinalKit(_: CardinalKitAppDelegate)` view modifier to apply your CardinalKit configuration to the main view in your SwiftUI `Scene`:
+```swift
+import CardinalKit
+import SwiftUI
+
+
+@main
+struct ExampleApp: App {
+    @UIApplicationDelegateAdaptor(CardinalKitAppDelegate.self) var appDelegate
+
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .cardinalKit(appDelegate)
+        }
+    }
+}
+```
+
+
+## 2. Modify Your CardinalKit Configuration
+
+A ``Configuration`` defines the ``Standard`` and ``Component``s that are used in a CardinalKit project.
+
+Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g., using the
+`FHIR` standard integrated into the CardinalKit Swift Package.
+
+The ``Configuration`` initializer requires a ``Standard`` that is used in the CardinalKit project.
+The standard defines a shared repository to facilitate communication between different modules.
+
+The ``Configuration/init(standard:_:)``'s components result builder allows the definition of different components, including conditional statements or loops.
+
+The following example demonstrates the usage of the `FHIR` standard and different built-in CardinalKit modules, including the `HealthKit` and `QuestionnaireDataSource` components:
+```swift
+import CardinalKit
+import FHIR
+import HealthKit
+import HealthKitDataSource
+import HealthKitToFHIRAdapter
+import Questionnaires
+import SwiftUI
+
+
+class ExampleAppDelegate: CardinalKitAppDelegate {
+    override var configuration: Configuration {
+        Configuration(standard: FHIR()) {
+            if HKHealthStore.isHealthDataAvailable() {
+                HealthKit {
+                    CollectSample(
+                        HKQuantityType(.stepCount),
+                        deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
+                    )
+                } adapter: {
+                    HealthKitToFHIRAdapter()
+                }
+            }
+            QuestionnaireDataSource()
+        }
+    }
+}
+```
+
+The ``Component`` documentation provides more information about the structure of components.
 
 ## Topics
 

--- a/Sources/CardinalKit/CardinalKit/CardinalKit.swift
+++ b/Sources/CardinalKit/CardinalKit/CardinalKit.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 /// Open-source framework for rapid development of modern, interoperable digital health applications.
 ///
-/// Set up the CardinalKit framework in your `App` instance of your SwiftUI applicaton using the ``CardinalKitAppDelegate`` and the `@UIApplicationDelegateAdaptor` property wrapper.
+/// Set up the CardinalKit framework in your `App` instance of your SwiftUI application using the ``CardinalKitAppDelegate`` and the `@UIApplicationDelegateAdaptor` property wrapper.
 /// Use the `View.cardinalKit(_: CardinalKitAppDelegate)` view modifier to apply your CardinalKit configuration to the main view in your SwiftUI `Scene`:
 /// ```swift
 /// import CardinalKit
@@ -33,7 +33,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g., using the
 /// `FHIR` standard integrated into the CardinalKit framework:
 /// ```swift
 /// import CardinalKit

--- a/Sources/CardinalKit/CardinalKit/CardinalKit.swift
+++ b/Sources/CardinalKit/CardinalKit/CardinalKit.swift
@@ -14,7 +14,7 @@ import SwiftUI
 ///
 /// Set up the CardinalKit framework in your `App` instance of your SwiftUI applicaton using the ``CardinalKitAppDelegate`` and the `@UIApplicationDelegateAdaptor` property wrapper.
 /// Use the `View.cardinalKit(_: CardinalKitAppDelegate)` view modifier to apply your CardinalKit configuration to the main view in your SwiftUI `Scene`:
-/// ```
+/// ```swift
 /// import CardinalKit
 /// import SwiftUI
 ///
@@ -32,6 +32,25 @@ import SwiftUI
 ///     }
 /// }
 /// ```
+///
+/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+/// `FHIR` standard integrated into the CardinalKit framework:
+/// ```swift
+/// import CardinalKit
+/// import FHIR
+///
+///
+/// class TemplateAppDelegate: CardinalKitAppDelegate {
+///     override var configuration: Configuration {
+///         Configuration(standard: FHIR()) {
+///             // Add your `Component`s here ...
+///        }
+///     }
+/// }
+/// ```
+///
+/// The ``Component`` documentation provides more information about the structure of components.
+/// Refer to the ``Configuration`` documentation to learn more about the CardinalKit configuration.
 public actor CardinalKit<S: Standard>: AnyCardinalKit, ObservableObject {
     /// A typesafe typedCollection of different elements of an ``CardinalKit/CardinalKit`` instance.
     public let typedCollection: TypedCollection

--- a/Sources/CardinalKit/CardinalKit/CardinalKitAppDelegate.swift
+++ b/Sources/CardinalKit/CardinalKit/CardinalKitAppDelegate.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 /// The ``CardinalKitAppDelegate`` is used to configure the CardinalKit-based application using the ``CardinalKitAppDelegate/configuration`` property.
 ///
-/// Set up the CardinalKit framework in your `App` instance of your SwiftUI applicaton using the ``CardinalKitAppDelegate`` and the `@UIApplicationDelegateAdaptor` property wrapper.
+/// Set up the CardinalKit framework in your `App` instance of your SwiftUI application using the ``CardinalKitAppDelegate`` and the `@UIApplicationDelegateAdaptor` property wrapper.
 /// Use the `View.cardinalKit(_: CardinalKitAppDelegate)` view modifier to apply your CardinalKit configuration to the main view in your SwiftUI `Scene`:
 /// ```swift
 /// import CardinalKit
@@ -32,7 +32,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g., using the
 /// `FHIR` standard integrated into the CardinalKit framework:
 /// ```swift
 /// import CardinalKit
@@ -68,7 +68,7 @@ open class CardinalKitAppDelegate: NSObject, UIApplicationDelegate {
     private(set) lazy var cardinalKit: AnyCardinalKit = configuration.cardinalKit
     
     
-    /// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+    /// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g., using the
     /// `FHIR` standard integrated into the CardinalKit framework:
     /// ```swift
     /// import CardinalKit

--- a/Sources/CardinalKit/CardinalKit/CardinalKitAppDelegate.swift
+++ b/Sources/CardinalKit/CardinalKit/CardinalKitAppDelegate.swift
@@ -31,6 +31,25 @@ import SwiftUI
 ///     }
 /// }
 /// ```
+///
+/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+/// `FHIR` standard integrated into the CardinalKit framework:
+/// ```swift
+/// import CardinalKit
+/// import FHIR
+///
+///
+/// class TemplateAppDelegate: CardinalKitAppDelegate {
+///     override var configuration: Configuration {
+///         Configuration(standard: FHIR()) {
+///             // Add your `Component`s here ...
+///        }
+///     }
+/// }
+/// ```
+///
+/// The ``Component`` documentation provides more information about the structure of components.
+/// Refer to the ``Configuration`` documentation to learn more about the CardinalKit configuration.
 open class CardinalKitAppDelegate: NSObject, UIApplicationDelegate {
     private actor DefaultStandard: Standard {
         typealias BaseType = StandardType
@@ -49,6 +68,24 @@ open class CardinalKitAppDelegate: NSObject, UIApplicationDelegate {
     private(set) lazy var cardinalKit: AnyCardinalKit = configuration.cardinalKit
     
     
+    /// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+    /// `FHIR` standard integrated into the CardinalKit framework:
+    /// ```swift
+    /// import CardinalKit
+    /// import FHIR
+    ///
+    ///
+    /// class TemplateAppDelegate: CardinalKitAppDelegate {
+    ///     override var configuration: Configuration {
+    ///         Configuration(standard: FHIR()) {
+    ///             // Add your `Component`s here ...
+    ///        }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// The ``Component`` documentation provides more information about the structure of components.
+    /// Refer to the ``Configuration`` documentation to learn more about the CardinalKit configuration.
     open var configuration: Configuration {
         Configuration(standard: DefaultStandard()) { }
     }

--- a/Sources/CardinalKit/Configuration/Component.swift
+++ b/Sources/CardinalKit/Configuration/Component.swift
@@ -8,6 +8,45 @@
 
 
 /// A ``Component`` defines a software subsystem that can be configured as part of the ``CardinalKitAppDelegate/configuration``.
+///
+/// The ``Component/ComponentStandard`` defines what Standard the component supports.
+/// The ``Component/configure()-m7ic`` method is called on the initialization of CardinalKit.
+///
+///
+/// **The Component Standard**
+///
+/// A ``Component`` can support any generic standard or add additional constraints using an optional where clause:
+/// ```swift
+/// class ExampleComponent<ComponentStandard: Standard>: Component where ComponentStandard: /* ... */ {
+///     /*... */
+/// }
+/// ```
+///
+/// ``Component``s can also specify support for only one specific ``Standard`` using a `typealias` definition:
+/// ```swift
+/// class ExampleFHIRComponent: Component {
+///     typealias ComponentStandard = FHIR
+/// }
+/// ```
+///
+///
+/// **Dependencies**
+///
+/// ``Component``s can define dependencies between each other using the @``Component/Dependency`` property wrapper.
+/// ```swift
+/// class ExampleComponent<ComponentStandard: Standard>: Component {
+///     @Dependency var exampleComponentDependency = ExampleComponentDependency()
+/// }
+/// ```
+///
+///
+/// **Additional Capabilities**
+///
+/// Componets can also conform to different additional protocols to provide additional access to CardinalKit features.
+/// - ``LifecycleHandler``: Delegate methods related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
+/// - ``ObservableObjectProvider``: A ``Component`` can conform to ``ObservableObjectProvider`` to inject `ObservableObject`s in the SwiftUI view hierarchy.
+///
+/// All these protocols are combined in the ``Module`` protocol, making it an easy one-stop solution to support all these different functionalities and build a capable CardinalKit module.
 public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey {
     /// A ``Component/ComponentStandard`` defines what ``Standard`` the component supports.
     associatedtype ComponentStandard: Standard

--- a/Sources/CardinalKit/Configuration/Component.swift
+++ b/Sources/CardinalKit/Configuration/Component.swift
@@ -42,8 +42,8 @@
 ///
 /// **Additional Capabilities**
 ///
-/// Componets can also conform to different additional protocols to provide additional access to CardinalKit features.
-/// - ``LifecycleHandler``: Delegate methods related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
+/// Components can also conform to different additional protocols to provide additional access to CardinalKit features.
+/// - ``LifecycleHandler``: Delegate methods are related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
 /// - ``ObservableObjectProvider``: A ``Component`` can conform to ``ObservableObjectProvider`` to inject `ObservableObject`s in the SwiftUI view hierarchy.
 ///
 /// All these protocols are combined in the ``Module`` protocol, making it an easy one-stop solution to support all these different functionalities and build a capable CardinalKit module.

--- a/Sources/CardinalKit/Configuration/Configuration.swift
+++ b/Sources/CardinalKit/Configuration/Configuration.swift
@@ -9,13 +9,13 @@
 
 /// A ``Configuration`` defines the ``Standard`` and ``Component``s that are used in a CardinalKit project.
 ///
-/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g., using the
 /// `FHIR` standard integrated into the CardinalKit Swift Package.
 ///
-/// The ``Configuration`` initalizer requires a ``Standard`` that is used in the CardinalKit project.
+/// The ``Configuration`` initializer requires a ``Standard`` that is used in the CardinalKit project.
 /// The standard defines a shared repository to facilitate communication between different modules.
 ///
-/// The ``Configuration/init(standard:_:)``'s components result builder allows the definition of different components including conditional statements or loops.
+/// The ``Configuration/init(standard:_:)``'s components result builder allows the definition of different components, including conditional statements or loops.
 ///
 /// The following example demonstrates the usage of the `FHIR` standard and different built-in CardinalKit modules, including the `HealthKit` and `QuestionnaireDataSource` components:
 /// ```swift

--- a/Sources/CardinalKit/Configuration/Configuration.swift
+++ b/Sources/CardinalKit/Configuration/Configuration.swift
@@ -8,6 +8,46 @@
 
 
 /// A ``Configuration`` defines the ``Standard`` and ``Component``s that are used in a CardinalKit project.
+///
+/// Register your different ``Component``s (or more sophisticated ``Module``s) using the ``CardinalKitAppDelegate/configuration`` property, e.g. using the
+/// `FHIR` standard integrated into the CardinalKit Swift Package.
+///
+/// The ``Configuration`` initalizer requires a ``Standard`` that is used in the CardinalKit project.
+/// The standard defines a shared repository to facilitate communication between different modules.
+///
+/// The ``Configuration/init(standard:_:)``'s components result builder allows the definition of different components including conditional statements or loops.
+///
+/// The following example demonstrates the usage of the `FHIR` standard and different built-in CardinalKit modules, including the `HealthKit` and `QuestionnaireDataSource` components:
+/// ```swift
+/// import CardinalKit
+/// import FHIR
+/// import HealthKit
+/// import HealthKitDataSource
+/// import HealthKitToFHIRAdapter
+/// import Questionnaires
+/// import SwiftUI
+///
+///
+/// class ExampleAppDelegate: CardinalKitAppDelegate {
+///     override var configuration: Configuration {
+///         Configuration(standard: FHIR()) {
+///             if HKHealthStore.isHealthDataAvailable() {
+///                 HealthKit {
+///                     CollectSample(
+///                         HKQuantityType(.stepCount),
+///                         deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
+///                     )
+///                 } adapter: {
+///                     HealthKitToFHIRAdapter()
+///                 }
+///             }
+///             QuestionnaireDataSource()
+///         }
+///     }
+/// }
+/// ```
+///
+/// The ``Component`` documentation provides more information about the structure of components.
 public struct Configuration {
     let cardinalKit: AnyCardinalKit
     

--- a/Sources/CardinalKit/DataSource/DataSourceRegistry.swift
+++ b/Sources/CardinalKit/DataSource/DataSourceRegistry.swift
@@ -8,8 +8,11 @@
 
 
 /// A ``DataSourceRegistry`` can recieve data from data sources using the ``DataSourceRegistry/registerDataSource(_:)`` method.
+///
 /// Each ``DataSourceRegistry`` has a ``DataSourceRegistry/BaseType`` that all data sources should provide.
-/// Use ``Adapter``s to transform data of different data sources.
+/// Use ``Adapter``s to transform data from different data sources.
+///
+/// ``Standard``s conforms to ``DataSourceRegistry`` as they serve as a shared repository to exchange information between CardinalKit modules.
 public protocol DataSourceRegistry<BaseType, RemovalContext>: Actor {
     /// The ``DataSourceRegistry/BaseType`` that all data sources should provide when adding or updating an element.
     associatedtype BaseType: Identifiable, Sendable where BaseType.ID: Sendable, BaseType.ID == RemovalContext.ID

--- a/Sources/CardinalKit/DataStorageProvider/DataStorageProvider.swift
+++ b/Sources/CardinalKit/DataStorageProvider/DataStorageProvider.swift
@@ -11,7 +11,7 @@
 /// A ``Standard`` instance can use the ``Standard/DataStorageProviders`` property wrapper to access all related ``DataStorageProvider``s.
 ///
 /// The following example uses a ``SingleValueAdapter`` to transform elements to an `DataStorageUploadable` representation:
-/// ```
+/// ```swift
 /// struct DataStorageUploadable: Encodable, Identifiable {
 ///     let id: String
 ///     let element: Encodable

--- a/Sources/CardinalKit/DataStorageProvider/Standard+DataStorageProviders.swift
+++ b/Sources/CardinalKit/DataStorageProvider/Standard+DataStorageProviders.swift
@@ -23,8 +23,8 @@ extension Standard {
 extension Standard {
     /// Defines access to the data storage providers in the ``Standard`` actor.
     ///
-    /// A ``Standard`` can gain access to all data storage providers using the `@```Standard/DataStorageProviders`` property wrapper:
-    /// ```
+    /// A ``Standard`` can gain access to all data storage providers using the @``Standard/DataStorageProviders`` property wrapper:
+    /// ```swift
     /// actor ExampleStandard: Standard {
     ///     @DataStorageProviders
     ///     var dataSources: [any DataStorageProvider<ExampleStandard>]

--- a/Sources/CardinalKit/Module/Capabilities/Dependencies/Component+Dependencies.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Dependencies/Component+Dependencies.swift
@@ -10,15 +10,15 @@
 extension Component {
     /// Defines a dependency to another ``Component``.
     ///
-    /// A ``Component`` can define the dependencies using the `@```Component/Dependency`` property wrapper:
-    /// ```
+    /// A ``Component`` can define the dependencies using the @``Component/Dependency`` property wrapper:
+    /// ```swift
     /// class ExampleComponent<ComponentStandard: Standard>: Component {
     ///     @Dependency var exampleComponentDependency = ExampleComponentDependency()
     /// }
     /// ```
     ///
     /// Some components do not need a default value assigned to the property if they provide a default configuration and conform to ``DefaultInitializable``.
-    /// ```
+    /// ```swift
     /// class ExampleComponent<ComponentStandard: Standard>: Component {
     ///     @Dependency var exampleComponentDependency: ExampleComponentDependency
     /// }
@@ -33,8 +33,8 @@ extension Component {
     /// In contrast to the `@Dependency` property wrapper, the `@DynamicDependencies` enables the generation of the property wrapper in the initializer and generating an
     /// arbitrary amount of dependencies that are resolved in the CardinalKit initialization.
     ///
-    /// A ``Component`` can define dynamic dependencies using the `@```Component/DynamicDependencies`` property wrapper and can, e.g., initialize its value in the initializer.
-    /// ```
+    /// A ``Component`` can define dynamic dependencies using the @``Component/DynamicDependencies`` property wrapper and can, e.g., initialize its value in the initializer.
+    /// ```swift
     /// class ExampleComponent<ComponentStandard: Standard>: Component {
     ///     @DynamicDependencies var dynamicDependencies: [any Component<ComponentStandard>]
     ///

--- a/Sources/CardinalKit/Module/Capabilities/Dependencies/DefaultInitializable.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Dependencies/DefaultInitializable.swift
@@ -9,6 +9,6 @@
 
 /// ``DefaultInitializable`` is used to identify ``Component``s that can be initialized without the need for additional context.
 public protocol DefaultInitializable {
-    /// A default initalizer with no arguments provided by conforming to ``DefaultInitializable``
+    /// A default initializer with no arguments provided by conforming to ``DefaultInitializable``
     init()
 }

--- a/Sources/CardinalKit/Module/Capabilities/Lifecycle/LifecycleHandler.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Lifecycle/LifecycleHandler.swift
@@ -10,7 +10,7 @@ import os
 import SwiftUI
 
 
-/// Delegate methods related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
+/// Delegate methods are related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
 ///
 /// Conform to the `LifecycleHandler` protocol to get updates about the application lifecycle similar to the `UIApplicationDelegate` on an app basis.
 public protocol LifecycleHandler {

--- a/Sources/CardinalKit/Module/Capabilities/Lifecycle/LifecycleHandler.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Lifecycle/LifecycleHandler.swift
@@ -10,7 +10,9 @@ import os
 import SwiftUI
 
 
-/// Delegate methods related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle
+/// Delegate methods related to the  `UIApplication` and ``CardinalKit/CardinalKit`` lifecycle.
+///
+/// Conform to the `LifecycleHandler` protocol to get updates about the application lifecycle similar to the `UIApplicationDelegate` on an app basis.
 public protocol LifecycleHandler {
     /// Replicates  the `application(_: UIApplication, willFinishLaunchingWithOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool`
     /// functionality of the `UIApplicationDelegate`.

--- a/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
+++ b/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
@@ -9,9 +9,46 @@
 import SwiftUI
 
 
-/// A ``Component`` can conform to ``ObservableObjectProvider`` to inject an `ObservableObject`s in the SwiftUI view hierachy using ``ObservableObjectProvider/observableObjects-6w1nz``
+/// A ``Component`` can conform to ``ObservableObjectProvider`` to inject `ObservableObject`s in the SwiftUI view hierarchy using ``ObservableObjectProvider/observableObjects-6w1nz``
+///
+///
+/// Reference types conforming to `ObservableObject` and be used in SwiftUI views to inform a view about changes in the object.
+/// You can create and use them in a view using `@ObservedObject` or get it from the SwiftUI environment using `@EnvironmentObject`.
+///
+/// A Component can conform to `ObservableObjectProvider` to inject `ObservableObject`s in the SwiftUI view hierarchy.
+/// You define all `ObservableObject`s that should be injected using the ``ObservableObjectProvider/observableObjects-5nl18`` property.
+/// ```swift
+/// class MyComponent<ComponentStandard: Standard>: ObservableObjectProvider {
+///     public var observableObjects: [any ObservableObject] {
+///         [/* ... */]
+///     }
+/// }
+/// ```
+///
+/// `ObservableObjectProvider` provides a default implementation of the ``ObservableObjectProvider/observableObjects-5nl18`` If your type conforms to `ObservableObject`
+/// that just injects itself into the SwiftUI view hierarchy:
+/// ```swift
+/// class MyComponent<ComponentStandard: Standard>: ObservableObject, ObservableObjectProvider {
+///     @Published
+///     var test: String
+///
+///     // ...
+/// }
+/// ```
 public protocol ObservableObjectProvider {
     /// The `ObservableObject` instances that should be injected in the SwiftUI environment.
+    ///
+    /// You define all `ObservableObject`s that should be injected using the ``ObservableObjectProvider/observableObjects-5nl18`` property.
+    /// ```swift
+    /// class MyComponent<ComponentStandard: Standard>: ObservableObjectProvider {
+    ///     public var observableObjects: [any ObservableObject] {
+    ///         [/* ... */]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// `ObservableObjectProvider` provides a default implementation of the ``ObservableObjectProvider/observableObjects-5nl18`` If your type conforms to `ObservableObject`
+    /// that just injects itself into the SwiftUI view hierarchy.
     var observableObjects: [any ObservableObject] { get }
 }
 

--- a/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
+++ b/Sources/CardinalKit/Module/Capabilities/ObservableObject/ObservableObjectComponent.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// A ``Component`` can conform to ``ObservableObjectProvider`` to inject `ObservableObject`s in the SwiftUI view hierarchy using ``ObservableObjectProvider/observableObjects-6w1nz``
 ///
 ///
-/// Reference types conforming to `ObservableObject` and be used in SwiftUI views to inform a view about changes in the object.
+/// Reference types conforming to `ObservableObject` can be used in SwiftUI views to inform a view about changes in the object.
 /// You can create and use them in a view using `@ObservedObject` or get it from the SwiftUI environment using `@EnvironmentObject`.
 ///
 /// A Component can conform to `ObservableObjectProvider` to inject `ObservableObject`s in the SwiftUI view hierarchy.

--- a/Sources/CardinalKit/Module/Module.swift
+++ b/Sources/CardinalKit/Module/Module.swift
@@ -9,5 +9,14 @@
 import SwiftUI
 
 
-/// A ``Module`` is a larger ``Component`` that is a ``LifecycleHandler``, persisted in the ``CardinalKit`` instance's ``CardinalKit/CardinalKit/typedCollection`` (using a conformance to ``TypedCollectionKey``), injected in the SwiftUI view hierachy (``ObservableObjectProvider`` & `ObservableObject`), and defined ``Component`` dependencies using `@```Component/Dependency`` property wrapper.
+/// A sophisticated ``Component`` with several built-in functionality.
+///
+/// A ``Module`` is a ``Component`` that also includes
+/// - Conformance to a ``LifecycleHandler``
+/// - Persistance in the ``CardinalKit`` instance's ``CardinalKit/CardinalKit/typedCollection`` (using a conformance to ``TypedCollectionKey``)
+/// - Automatic injection in the SwiftUI view hierachy (``ObservableObjectProvider`` & `ObservableObject`)
+///
+/// All functionality provided to ``Component``s is also available to ``Module``s including dependencies using the @``Component/Dependency`` property wrapper.
+///
+/// Please take a look at the ``Component`` documentation for more information.
 public typealias Module = Component & LifecycleHandler & ObservableObjectProvider & ObservableObject & TypedCollectionKey

--- a/Sources/CardinalKit/Standard/Component+Standard.swift
+++ b/Sources/CardinalKit/Standard/Component+Standard.swift
@@ -22,8 +22,8 @@ extension Component {
 extension Component {
     /// Defines access to the shared ``Standard`` actor.
     ///
-    /// A ``Component`` can define the injection of a ``Standard`` using the `@```Component/StandardActor`` property wrapper:
-    /// ```
+    /// A ``Component`` can define the injection of a ``Standard`` using the @``Component/StandardActor`` property wrapper:
+    /// ```swift
     /// class ExampleComponent: Component {
     ///     typealias ComponentStandard = ExampleStandard
     ///

--- a/Sources/CardinalKit/Standard/Standard.swift
+++ b/Sources/CardinalKit/Standard/Standard.swift
@@ -6,6 +6,44 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Combine
 
-/// A ``Standard`` defines a common representation of resources using by different `CardinalKit` components.
+/// A ``Standard`` defines a common representation of resources used by different `CardinalKit` components.
+///
+/// A ``Standard`` is a ``DataSourceRegistry`` that needs to define a ``DataSourceRegistry/BaseType`` and a ``DataSourceRegistry/RemovalContext``
+/// and a ``DataSourceRegistry/registerDataSource(_:)`` method.
+/// Different ``Standard``s can define different ``DataSourceRegistry/BaseType`` and a ``DataSourceRegistry/RemovalContext`` forming a central representation
+/// that is shared across ``Component``s.
+///
+/// The following example demonstrates a minimal ``Standard`` implementation.
+/// ```swift
+/// actor TestAppStandard: Standard, ObservableObjectProvider, ObservableObject {
+///     typealias BaseType = TestAppStandardBaseType
+///     typealias RemovalContext = TestAppStandardRemovalContext
+///
+///
+///     struct TestAppStandardBaseType: Identifiable, Sendable {
+///         var id: String
+///         var content: Int
+///
+///
+///         var removalContext: TestAppStandardRemovalContext {
+///             TestAppStandardRemovalContext(id: id)
+///         }
+///     }
+///
+///     struct TestAppStandardRemovalContext: Identifiable, Sendable {
+///         var id: TestAppStandardBaseType.ID
+///     }
+///
+///
+///     func registerDataSource(_ asyncSequence: some TypedAsyncSequence<DataChange<BaseType, RemovalContext>>) {
+///         // ...
+///     }
+/// }
+/// ```
+///
+/// You can access the current ``Standard`` instance in your ``Component`` or ``Module`` using the @``Component/StandardActor`` property wrapper.
+///
+/// CardinalKit includes a built-in `FHIR` standard that you can use in your digital health applications.
 public protocol Standard<BaseType>: Actor, Component, DataSourceRegistry where ComponentStandard == Self { }

--- a/Sources/CardinalKit/Standard/Standard.swift
+++ b/Sources/CardinalKit/Standard/Standard.swift
@@ -6,8 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Combine
-
 /// A ``Standard`` defines a common representation of resources used by different `CardinalKit` components.
 ///
 /// A ``Standard`` is a ``DataSourceRegistry`` that needs to define a ``DataSourceRegistry/BaseType`` and a ``DataSourceRegistry/RemovalContext``

--- a/Sources/Contact/Contact Views/ContactsList.swift
+++ b/Sources/Contact/Contact Views/ContactsList.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// A ``ContactsList`` enables the display of different ``ContactView``s in a card-like style in a scroll view.
 ///
 /// You pass multiple ``Contact``s to the ``ContactsList`` to populate its content: ``ContactsList/init(contacts:)``:
-/// ```
+/// ```swift
 /// ContactsList(contacts: [/* ... */])
 ///     .navigationTitle("Contacts")
 ///     .background(Color(.systemGroupedBackground))

--- a/Sources/FHIR/FHIR.swift
+++ b/Sources/FHIR/FHIR.swift
@@ -83,8 +83,13 @@ public actor FHIR: Standard, ObservableObject, ObservableObjectProvider {
     }
     
     
-    @Published
-    private var resources: [Resource.ID: ResourceProxy] = [:]
+    private var resources: [Resource.ID: ResourceProxy] = [:] {
+        didSet {
+            _Concurrency.Task { @MainActor in
+                objectWillChange.send()
+            }
+        }
+    }
     
     @DataStorageProviders
     var dataStorageProviders: [any DataStorageProvider<FHIR>]

--- a/Sources/HealthKitDataSource/HealthKit.swift
+++ b/Sources/HealthKitDataSource/HealthKit.swift
@@ -15,7 +15,7 @@ import SwiftUI
 ///
 /// Use the ``HealthKit/init(_:adapter:)`` initializer to define different ``HealthKitDataSourceDescription``s to define the data collection.
 /// You can, e.g., use ``CollectSample`` to collect a wide variaty of `HKSampleTypes`:
-/// ```
+/// ```swift
 /// class ExampleAppDelegate: CardinalKitAppDelegate {
 ///     override var configuration: Configuration {
 ///         Configuration(standard: ExampleStandard()) {

--- a/Sources/Onboarding/ConsentView.swift
+++ b/Sources/Onboarding/ConsentView.swift
@@ -16,7 +16,7 @@ import Views
 /// The ``ConsentView`` provides a convenience initalizer with a provided action view using an ``OnboardingActionsView`` (``ConsentView/init(header:asyncMarkdown:footer:action:)``)
 /// or a more customized ``ConsentView/init(contentView:actionView:)`` initializer with a custom-provided content and action view.
 ///
-/// ```
+/// ```swift
 /// ConsentView(
 ///     asyncMarkdown: {
 ///         Data("This is a *markdown* **example**".utf8)

--- a/Sources/Onboarding/ConsentView.swift
+++ b/Sources/Onboarding/ConsentView.swift
@@ -13,7 +13,7 @@ import Views
 
 /// The ``ConsentView`` allows the display of markdown-based documents that can be signed using a family and given name and a hand drawn signature.
 ///
-/// The ``ConsentView`` provides a convenience initalizer with a provided action view using an ``OnboardingActionsView`` (``ConsentView/init(header:asyncMarkdown:footer:action:)``)
+/// The ``ConsentView`` provides a convenience initializer with a provided action view using an ``OnboardingActionsView`` (``ConsentView/init(header:asyncMarkdown:footer:action:)``)
 /// or a more customized ``ConsentView/init(contentView:actionView:)`` initializer with a custom-provided content and action view.
 ///
 /// ```swift

--- a/Sources/Onboarding/OnboardingActionsView.swift
+++ b/Sources/Onboarding/OnboardingActionsView.swift
@@ -13,7 +13,7 @@ import Views
 /// The ``OnboardingActionsView`` allows developers to present a unified style for action buttons in an onboarding flow.
 /// The ``OnboardingActionsView`` can contain one primary button and a optional secondary button below the primary button.
 ///
-/// ```
+/// ```swift
 /// OnboardingActionsView(
 ///     primaryText: "Primary Text",
 ///     primaryAction: {

--- a/Sources/Onboarding/OnboardingInformationView.swift
+++ b/Sources/Onboarding/OnboardingInformationView.swift
@@ -14,7 +14,7 @@ import Views
 /// by the ``OnboardingInformationView/Content`` type.
 ///
 /// The following example displays an ``OnboardingInformationView`` with two information areas:
-/// ```
+/// ```swift
 /// OnboardingInformationView(
 ///     areas: [
 ///         OnboardingInformationView.Content(

--- a/Sources/Onboarding/OnboardingTitleView.swift
+++ b/Sources/Onboarding/OnboardingTitleView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// The ``OnboardingTitleView`` allows developers to present a unified style for the in an onboarding flow.
 /// The ``OnboardingTitleView`` can contain one title and a optional subtitle below the title.
 ///
-/// ```
+/// ```swift
 /// OnboardingTitleView(title: "Title", subtitle: "Subtitle")
 /// ```
 public struct OnboardingTitleView: View {

--- a/Sources/Onboarding/OnboardingView.swift
+++ b/Sources/Onboarding/OnboardingView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 /// sequential information that is displayed step by step.
 ///
 /// The following example demonstrates the usage of the ``OnboardingView`` using its default configuration.
-/// ```
+/// ```swift
 /// OnboardingView(
 ///     title: "Title",
 ///     subtitle: "Subtitle",

--- a/Sources/Onboarding/SequentialOnboardingView.swift
+++ b/Sources/Onboarding/SequentialOnboardingView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// The ``OnboardingView`` provides an alternative to provide  information that is displayed all at once.
 ///
 /// The following example demonstrates the usage of the ``SequentialOnboardingView``:
-/// ```
+/// ```swift
 /// SequentialOnboardingView(
 ///     title: "Title",
 ///     subtitle: "Subtitle",

--- a/Sources/Onboarding/SignatureView.swift
+++ b/Sources/Onboarding/SignatureView.swift
@@ -14,7 +14,7 @@ import Views
 /// A ``SignatureView`` enables the collection of signatures using a view that allows freeform signatures using a finger and the Apple Pencil.
 ///
 /// Use SwiftUI `Bindings` to obtain information like the content of the signature and if the user is currently signing:
-/// ```
+/// ```swift
 /// @State var signature = PKDrawing()
 /// @State var isSigning = false
 /// 

--- a/Sources/Questionnaires/QuestionnaireDataSource.swift
+++ b/Sources/Questionnaires/QuestionnaireDataSource.swift
@@ -16,7 +16,7 @@ import SwiftUI
 ///
 /// Use the ``QuestionnaireDataSource/init(adapter:)`` initializer to add the data source to your `Configuration`.
 /// You can use the ``QuestionnaireDataSource/init()`` initializer of you use the FHIR standard in your CardinalKit application:
-/// ```
+/// ```swift
 /// class ExampleAppDelegate: CardinalKitAppDelegate {
 ///     override var configuration: Configuration {
 ///         Configuration(standard: FHIR()) {

--- a/Sources/Views/Drawing/CanvasView.swift
+++ b/Sources/Views/Drawing/CanvasView.swift
@@ -99,7 +99,7 @@ private struct _CanvasView: UIViewRepresentable {
 /// current canvas size using the SwiftUI preference mechanisms.
 ///
 /// The view offers several bindings to observe the resulting drawing, check if a user is currently drawing, and showing or hiding the tool picker.
-/// ```
+/// ```swift
 /// @State var drawing = PKDrawing()
 /// @State var isDrawing = false
 /// @State var showToolPicker = false

--- a/Sources/Views/Text/MarkdownView.swift
+++ b/Sources/Views/Text/MarkdownView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 /// A ``MarkdownView`` allows the display of a markdown file including the addition of a header and footer view.
 ///
-/// ```
+/// ```swift
 /// @State var viewState: ViewState = .idle
 ///
 /// MarkdownView(


### PR DESCRIPTION
# Add Documentation for the Main CardinalKit Module

## :recycle: Current situation & Problem
The main CardinalKit module currently does not include detailed documentation about building modules and using the core types in the framework.

## :bulb: Proposed solution
This PR adds a DocC-based documentation for the main target.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

