### PR TITLE
FHIR Mock Data Storage Provider

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,43 +16,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_test_spm:
+  build_and_test-spm:
     name: Build and Test Swift Package
-    runs-on: macos-12
-    env:
+    uses: StanfordBDHG/.github/.github/workflows/build-and-test-xcodebuild-spm.yml@v1
+    with:
       scheme: CardinalKit-Package
-    steps:
-    - uses: actions/checkout@v3
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Install xcpretty
-      run: gem install xcpretty
-    - name: Check Environment
-      run: |
-          xcodebuild -version
-          swift --version
-          echo "env.scheme: ${{ env.scheme }}"
-    - name: Resolve Dependencies
-      run: xcodebuild -resolvePackageDependencies
-    - name: Build and Test
-      run: |
-          set -o pipefail \
-          && xcodebuild test \
-            -scheme ${{ env.scheme }} \
-            -sdk iphonesimulator \
-            -destination "name=iPhone 14 Pro Max" \
-            -enableCodeCoverage YES \
-            -resultBundlePath ${{ env.scheme }}.xcresult \
-            CODE_SIGNING_ALLOWED=NO \
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS=TEST \
-          | xcpretty
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ env.scheme }}.xcresult
-        path: ${{ env.scheme }}.xcresult
-  build_and_test_uitests:
+  build_and_test-uitests:
     name: Build and Test UITests
     runs-on: macos-12
     defaults:
@@ -101,7 +70,7 @@ jobs:
         path: Tests/UITests/${{ env.scheme }}.xcresult
   create-and-upload-coverage-report:
     name: Create and Upload Coverage Report
-    needs: [build_and_test_spm, build_and_test_uitests]
+    needs: [build_and_test-spm, build_and_test-uitests]
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v1
     with:
       coveragereports: CardinalKit-Package.xcresult TestApp.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,12 +16,43 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_test-spm:
+  build_and_test_spm:
     name: Build and Test Swift Package
-    uses: StanfordBDHG/.github/.github/workflows/build-and-test-xcodebuild-spm.yml@v1
-    with:
+    runs-on: macos-12
+    env:
       scheme: CardinalKit-Package
-  build_and_test-uitests:
+    steps:
+    - uses: actions/checkout@v3
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - name: Install xcpretty
+      run: gem install xcpretty
+    - name: Check Environment
+      run: |
+          xcodebuild -version
+          swift --version
+          echo "env.scheme: ${{ env.scheme }}"
+    - name: Resolve Dependencies
+      run: xcodebuild -resolvePackageDependencies
+    - name: Build and Test
+      run: |
+          set -o pipefail \
+          && xcodebuild test \
+            -scheme ${{ env.scheme }} \
+            -sdk iphonesimulator \
+            -destination "name=iPhone 14 Pro Max" \
+            -enableCodeCoverage YES \
+            -resultBundlePath ${{ env.scheme }}.xcresult \
+            CODE_SIGNING_ALLOWED=NO \
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS=TEST \
+          | xcpretty
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.scheme }}.xcresult
+        path: ${{ env.scheme }}.xcresult
+  build_and_test_uitests:
     name: Build and Test UITests
     runs-on: macos-12
     defaults:
@@ -70,7 +101,7 @@ jobs:
         path: Tests/UITests/${{ env.scheme }}.xcresult
   create-and-upload-coverage-report:
     name: Create and Upload Coverage Report
-    needs: [build_and_test-spm, build_and_test-uitests]
+    needs: [build_and_test_spm, build_and_test_uitests]
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v1
     with:
       coveragereports: CardinalKit-Package.xcresult TestApp.xcresult

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .library(name: "CardinalKit", targets: ["CardinalKit"]),
         .library(name: "Contact", targets: ["Contact"]),
         .library(name: "FHIR", targets: ["FHIR"]),
+        .library(name: "FHIRMockDataStorageProvider", targets: ["FHIRMockDataStorageProvider"]),
         .library(name: "FHIRToFirestoreAdapter", targets: ["FHIRToFirestoreAdapter"]),
         .library(name: "FirestoreDataStorage", targets: ["FirestoreDataStorage"]),
         .library(name: "FirestoreStoragePrefixUserIdAdapter", targets: ["FirestoreStoragePrefixUserIdAdapter"]),
@@ -105,6 +106,17 @@ let package = Package(
                 .target(name: "CardinalKit"),
                 .target(name: "FirebaseConfiguration"),
                 .product(name: "FirebaseAuth", package: "firebase-ios-sdk")
+            ]
+        ),
+        .target(
+            name: "FHIRMockDataStorageProvider",
+            dependencies: [
+                .target(name: "CardinalKit"),
+                .target(name: "FHIR"),
+                .target(name: "Views")
+            ],
+            resources: [
+                .process("Resources")
             ]
         ),
         .target(

--- a/Sources/Account/AccountServicesView.swift
+++ b/Sources/Account/AccountServicesView.swift
@@ -49,6 +49,7 @@ struct AccountServicesView<Header: View>: View {
 }
 
 
+#if DEBUG
 struct AccountServicesView_Previews: PreviewProvider {
     @StateObject private static var account: Account = {
         let accountServices: [any AccountService] = [
@@ -65,3 +66,4 @@ struct AccountServicesView_Previews: PreviewProvider {
             .environmentObject(account)
     }
 }
+#endif

--- a/Sources/Account/Login.swift
+++ b/Sources/Account/Login.swift
@@ -36,6 +36,7 @@ public struct Login<Header: View>: View {
 }
 
 
+#if DEBUG
 struct Login_Previews: PreviewProvider {
     @StateObject private static var account: Account = {
         let accountServices: [any AccountService] = [
@@ -53,3 +54,4 @@ struct Login_Previews: PreviewProvider {
             .environmentObject(account)
     }
 }
+#endif

--- a/Sources/Account/SignUp.swift
+++ b/Sources/Account/SignUp.swift
@@ -36,6 +36,7 @@ public struct SignUp<Header: View>: View {
 }
 
 
+#if DEBUG
 struct SignUp_Previews: PreviewProvider {
     @StateObject private static var account: Account = {
         let accountServices: [any AccountService] = [
@@ -52,3 +53,4 @@ struct SignUp_Previews: PreviewProvider {
             .environmentObject(account)
     }
 }
+#endif

--- a/Sources/Account/Username and Password/Login/UsernamePasswordLoginView.swift
+++ b/Sources/Account/Username and Password/Login/UsernamePasswordLoginView.swift
@@ -162,6 +162,7 @@ public struct UsernamePasswordLoginView: View {
 }
 
 
+#if DEBUG
 struct UsernamePasswordLoginView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
@@ -170,3 +171,4 @@ struct UsernamePasswordLoginView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Account/Username and Password/ResetPassword/UsernamePasswordResetPasswordView.swift
+++ b/Sources/Account/Username and Password/ResetPassword/UsernamePasswordResetPasswordView.swift
@@ -167,6 +167,7 @@ public struct UsernamePasswordResetPasswordView: View {
 }
 
 
+#if DEBUG
 struct UsernamePasswordResetPasswordView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
@@ -177,3 +178,4 @@ struct UsernamePasswordResetPasswordView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Account/Username and Password/Shared/DataEntryAccountView.swift
+++ b/Sources/Account/Username and Password/Shared/DataEntryAccountView.swift
@@ -104,6 +104,7 @@ struct DataEntryAccountView: View {
 }
 
 
+#if DEBUG
 struct DataEntryView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
@@ -121,3 +122,4 @@ struct DataEntryView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Account/Username and Password/Shared/UsernamePasswordFields.swift
+++ b/Sources/Account/Username and Password/Shared/UsernamePasswordFields.swift
@@ -282,6 +282,7 @@ struct UsernamePasswordFields: View {
 }
 
 
+#if DEBUG
 struct UsernamePasswordFields_Previews: PreviewProvider {
     @State private static var username: String = ""
     @State private static var password: String = ""
@@ -330,3 +331,4 @@ struct UsernamePasswordFields_Previews: PreviewProvider {
             .environmentObject(UsernamePasswordAccountService())
     }
 }
+#endif

--- a/Sources/Account/Username and Password/Sign Up/DateOfBirthPicker.swift
+++ b/Sources/Account/Username and Password/Sign Up/DateOfBirthPicker.swift
@@ -63,6 +63,7 @@ struct DateOfBirthPicker: View {
 }
 
 
+#if DEBUG
 struct DateOfBirthPicker_Previews: PreviewProvider {
     @State private static var date = Date.now
     
@@ -80,3 +81,4 @@ struct DateOfBirthPicker_Previews: PreviewProvider {
             .background(Color(.systemGroupedBackground))
     }
 }
+#endif

--- a/Sources/Account/Username and Password/Sign Up/GenderIdentityPicker.swift
+++ b/Sources/Account/Username and Password/Sign Up/GenderIdentityPicker.swift
@@ -53,6 +53,7 @@ struct GenderIdentityPicker: View {
 }
 
 
+#if DEBUG
 struct GenderIdentityPicker_Previews: PreviewProvider {
     @State private static var genderIdentity: GenderIdentity = .male
     
@@ -74,3 +75,4 @@ struct GenderIdentityPicker_Previews: PreviewProvider {
             .background(Color(.systemGroupedBackground))
     }
 }
+#endif

--- a/Sources/Account/Username and Password/Sign Up/NameTextFields.swift
+++ b/Sources/Account/Username and Password/Sign Up/NameTextFields.swift
@@ -74,6 +74,7 @@ struct NameTextFields: View {
 }
 
 
+#if DEBUG
 struct NameTextFields_Previews: PreviewProvider {
     @State private static var name = PersonNameComponents()
     
@@ -91,3 +92,4 @@ struct NameTextFields_Previews: PreviewProvider {
             .background(Color(.systemGroupedBackground))
     }
 }
+#endif

--- a/Sources/Account/Username and Password/Sign Up/UsernamePasswordSignUpView.swift
+++ b/Sources/Account/Username and Password/Sign Up/UsernamePasswordSignUpView.swift
@@ -257,6 +257,7 @@ public struct UsernamePasswordSignUpView: View {
 }
 
 
+#if DEBUG
 struct UsernamePasswordSignUpView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
@@ -265,3 +266,4 @@ struct UsernamePasswordSignUpView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Account/Views/AccountServiceButton.swift
+++ b/Sources/Account/Views/AccountServiceButton.swift
@@ -35,6 +35,7 @@ struct AccountServiceButton<Content: View>: View {
 }
 
 
+#if DEBUG
 struct UsernamePasswordLoginServiceButton_Previews: PreviewProvider {
     static var previews: some View {
         AccountServiceButton {
@@ -44,3 +45,4 @@ struct UsernamePasswordLoginServiceButton_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Account/Views/VerifiableTextGridRow.swift
+++ b/Sources/Account/Views/VerifiableTextGridRow.swift
@@ -120,6 +120,7 @@ struct VerifiableTextFieldGridRow<Description: View, TextField: View>: View {
 }
 
 
+#if DEBUG
 struct VerifiableTextFieldGridRow_Previews: PreviewProvider {
     private enum Field: Hashable {
         case first
@@ -176,3 +177,4 @@ struct VerifiableTextFieldGridRow_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Contact/Contact Views/ContactCard.swift
+++ b/Sources/Contact/Contact Views/ContactCard.swift
@@ -31,9 +31,11 @@ struct ContactCard: View {
 }
 
 
+#if DEBUG
 struct ContactCard_Previews: PreviewProvider {
     static var previews: some View {
         ContactCard(contact: ContactView_Previews.mock)
             .padding()
     }
 }
+#endif

--- a/Sources/Contact/Contact Views/ContactView.swift
+++ b/Sources/Contact/Contact Views/ContactView.swift
@@ -167,6 +167,7 @@ public struct ContactView: View {
 }
 
 
+#if DEBUG
 struct ContactView_Previews: PreviewProvider {
     static var mock: Contact {
         Contact(
@@ -202,3 +203,4 @@ struct ContactView_Previews: PreviewProvider {
         ContactView(contact: Self.mock)
     }
 }
+#endif

--- a/Sources/Contact/Contact Views/ContactsList.swift
+++ b/Sources/Contact/Contact Views/ContactsList.swift
@@ -42,6 +42,7 @@ public struct ContactsList: View {
 }
 
 
+#if DEBUG
 struct ContactsList_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
@@ -57,3 +58,4 @@ struct ContactsList_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/FHIRMockDataStorageProvider/MockDataStorageProvider.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockDataStorageProvider.swift
@@ -1,0 +1,60 @@
+//
+// This source file is part of the Stanford CardinalKit Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import FHIR
+import Foundation
+
+
+/// A data storage provider that collects all uploads and displays them in a user interface using the ``MockUploadList``.
+public actor MockDataStorageProvider: DataStorageProvider, ObservableObjectProvider, ObservableObject {
+    public typealias ComponentStandard = FHIR
+    
+    
+    let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }()
+    @MainActor @Published
+    private(set) var mockUploads: [MockUpload] = []
+    
+    
+    public init() { }
+    
+    
+    public func process(_ element: DataChange<ComponentStandard.BaseType, ComponentStandard.RemovalContext>) async throws {
+        switch element {
+        case let .addition(element):
+            let data = try encoder.encode(element)
+            let json = String(decoding: data, as: UTF8.self)
+            _Concurrency.Task { @MainActor in
+                mockUploads.insert(
+                    MockUpload(
+                        id: element.id.description,
+                        type: .add,
+                        path: ResourceProxy(with: element).resourceType.description,
+                        body: json
+                    ),
+                    at: 0
+                )
+            }
+        case let .removal(removalContext):
+            _Concurrency.Task { @MainActor in
+                mockUploads.insert(
+                    MockUpload(
+                        id: removalContext.id.description,
+                        type: .delete,
+                        path: removalContext.resourceType.rawValue
+                    ),
+                    at: 0
+                )
+            }
+        }
+    }
+}

--- a/Sources/FHIRMockDataStorageProvider/MockDataStorageProvider.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockDataStorageProvider.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford CardinalKit Template Application project
+// This source file is part of the CardinalKit open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/Sources/FHIRMockDataStorageProvider/MockUpload.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUpload.swift
@@ -1,0 +1,37 @@
+//
+// This source file is part of the Stanford CardinalKit Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+struct MockUpload: Identifiable, Hashable {
+    enum UploadType {
+        case add
+        case delete
+    }
+    
+    
+    let identifier: String
+    let date = Date()
+    let type: UploadType
+    let path: String
+    let body: String?
+    
+    
+    var id: String {
+        "\(type): \(path)/\(identifier) at \(date.debugDescription)"
+    }
+    
+    
+    init(id: String, type: UploadType, path: String, body: String? = nil) {
+        self.identifier = id
+        self.type = type
+        self.path = path
+        self.body = body
+    }
+}

--- a/Sources/FHIRMockDataStorageProvider/MockUpload.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUpload.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford CardinalKit Template Application project
+// This source file is part of the CardinalKit open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/Sources/FHIRMockDataStorageProvider/MockUploadDetailView.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUploadDetailView.swift
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Stanford CardinalKit Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import Views
+
+
+struct MockUploadDetailView: View {
+    let mockUpload: MockUpload
+    
+    
+    var body: some View {
+        List {
+            Section(String(localized: "MOCK_UPLOAD_DETAIL_HEADER", bundle: .module)) {
+                MockUploadHeader(mockUpload: mockUpload)
+            }
+            Section(String(localized: "MOCK_UPLOAD_DETAIL_BODY", bundle: .module)) {
+                LazyText(text: mockUpload.body ?? "")
+            }
+        }
+            .listStyle(.insetGrouped)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+
+#if DEBUG
+struct MockUploadDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        MockUploadDetailView(
+            mockUpload: MockUpload(
+                id: UUID().uuidString,
+                type: .add,
+                path: "A Path",
+                body: "A Body ..."
+            )
+        )
+    }
+}
+#endif

--- a/Sources/FHIRMockDataStorageProvider/MockUploadDetailView.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUploadDetailView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford CardinalKit Template Application project
+// This source file is part of the CardinalKit open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/Sources/FHIRMockDataStorageProvider/MockUploadHeader.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUploadHeader.swift
@@ -1,0 +1,62 @@
+//
+// This source file is part of the Stanford CardinalKit Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct MockUploadHeader: View {
+    let mockUpload: MockUpload
+    
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .center, spacing: 12) {
+                switch mockUpload.type {
+                case .add:
+                    Image(systemName: "arrow.up.doc.fill")
+                        .foregroundColor(.green)
+                case .delete:
+                    Image(systemName: "trash.fill")
+                        .foregroundColor(.red)
+                }
+                Text("/\(mockUpload.path)/")
+            }
+                .font(.title3)
+                .bold()
+                .padding(.bottom, 12)
+            Text("On \(format(mockUpload.date))")
+                .font(.subheadline)
+            Text("\(mockUpload.identifier)")
+                .font(.footnote)
+                .foregroundColor(.gray)
+        }
+    }
+    
+    
+    private func format(_ date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .long
+        dateFormatter.timeStyle = .long
+        return dateFormatter.string(from: date)
+    }
+}
+
+
+#if DEBUG
+struct MockUploadHeader_Previews: PreviewProvider {
+    static var previews: some View {
+        MockUploadHeader(
+            mockUpload: MockUpload(
+                id: UUID().uuidString,
+                type: .add,
+                path: "A Path"
+            )
+        )
+    }
+}
+#endif

--- a/Sources/FHIRMockDataStorageProvider/MockUploadHeader.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUploadHeader.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford CardinalKit Template Application project
+// This source file is part of the CardinalKit open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/Sources/FHIRMockDataStorageProvider/MockUploadList.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUploadList.swift
@@ -1,0 +1,63 @@
+//
+// This source file is part of the Stanford CardinalKit Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+/// Displays the recoded uploads collected by the ``MockDataStorageProvider``.
+public struct MockUploadList: View {
+    @EnvironmentObject var mockDataStorageProvider: MockDataStorageProvider
+    
+    
+    public var body: some View {
+        Group {
+            if mockDataStorageProvider.mockUploads.isEmpty {
+                VStack(spacing: 32) {
+                    Image(systemName: "server.rack")
+                        .font(.system(size: 100))
+                    Text(String(localized: "MOCK_UPLOAD_LIST_PLACEHOLDER", bundle: .module))
+                        .multilineTextAlignment(.center)
+                }
+                    .padding(32)
+            } else {
+                List(mockDataStorageProvider.mockUploads) { mockUpload in
+                    NavigationLink(value: mockUpload) {
+                        MockUploadHeader(mockUpload: mockUpload)
+                    }
+                }
+            }
+        }
+            .navigationDestination(for: MockUpload.self) { mockUpload in
+                MockUploadDetailView(mockUpload: mockUpload)
+            }
+            .navigationTitle(String(localized: "MOCK_UPLOAD_LIST_TITLE", bundle: .module))
+    }
+    
+    
+    public init() {}
+    
+    
+    private func format(_ date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .long
+        dateFormatter.timeStyle = .long
+        return dateFormatter.string(from: date)
+    }
+}
+
+
+#if DEBUG
+struct MockUploadsList_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            MockUploadList()
+                .environmentObject(MockDataStorageProvider())
+        }
+    }
+}
+#endif

--- a/Sources/FHIRMockDataStorageProvider/MockUploadList.swift
+++ b/Sources/FHIRMockDataStorageProvider/MockUploadList.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford CardinalKit Template Application project
+// This source file is part of the CardinalKit open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/Sources/FHIRMockDataStorageProvider/Resources/en.lproj/Localizable.strings
+++ b/Sources/FHIRMockDataStorageProvider/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,13 @@
+//
+// This source file is part of the Stanford CardinalKit Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+// MARK: - Mock Upload Data Storage Provider
+"MOCK_UPLOAD_LIST_PLACEHOLDER" = "The Mock Upload Data Storage Provider will display all uploads that would be triggered by the FHIR standard.";
+"MOCK_UPLOAD_LIST_TITLE" = "Mock Upload";
+"MOCK_UPLOAD_DETAIL_HEADER" = "Upload Header";
+"MOCK_UPLOAD_DETAIL_BODY" = "Upload Body";

--- a/Sources/FHIRMockDataStorageProvider/Resources/en.lproj/Localizable.strings
+++ b/Sources/FHIRMockDataStorageProvider/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford CardinalKit Template Application project
+// This source file is part of the CardinalKit open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/Sources/Onboarding/ConsentView.swift
+++ b/Sources/Onboarding/ConsentView.swift
@@ -121,6 +121,7 @@ public struct ConsentView<ContentView: View, Action: View>: View {
 }
 
 
+#if DEBUG
 struct ConsentView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
@@ -136,3 +137,4 @@ struct ConsentView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Onboarding/OnboardingActionsView.swift
+++ b/Sources/Onboarding/OnboardingActionsView.swift
@@ -123,6 +123,7 @@ public struct OnboardingActionsView: View {
 }
 
 
+#if DEBUG
 struct OnboardingActionsView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
@@ -142,3 +143,4 @@ struct OnboardingActionsView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Onboarding/OnboardingInformationView.swift
+++ b/Sources/Onboarding/OnboardingInformationView.swift
@@ -98,6 +98,7 @@ public struct OnboardingInformationView: View {
 }
 
 
+#if DEBUG
 struct AreasView_Previews: PreviewProvider {
     static var mock: [OnboardingInformationView.Content] {
         [
@@ -137,3 +138,4 @@ struct AreasView_Previews: PreviewProvider {
         )
     }
 }
+#endif

--- a/Sources/Onboarding/OnboardingTitleView.swift
+++ b/Sources/Onboarding/OnboardingTitleView.swift
@@ -55,8 +55,10 @@ public struct OnboardingTitleView: View {
 }
 
 
+#if DEBUG
 struct OnboardingTitleView_Previews: PreviewProvider {
     static var previews: some View {
         OnboardingTitleView(title: "Title", subtitle: "Subtitle")
     }
 }
+#endif

--- a/Sources/Onboarding/OnboardingView.swift
+++ b/Sources/Onboarding/OnboardingView.swift
@@ -115,6 +115,7 @@ public struct OnboardingView<TitleView: View, ContentView: View, ActionView: Vie
 }
 
 
+#if DEBUG
 struct OnboardingView_Previews: PreviewProvider {
     static var previews: some View {
         OnboardingView(
@@ -127,3 +128,4 @@ struct OnboardingView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Onboarding/SequentialOnboardingView.swift
+++ b/Sources/Onboarding/SequentialOnboardingView.swift
@@ -184,6 +184,7 @@ public struct SequentialOnboardingView: View {
 }
 
 
+#if DEBUG
 struct SequentialOnboardingView_Previews: PreviewProvider {
     static var mock: [SequentialOnboardingView.Content] {
         [
@@ -204,3 +205,4 @@ struct SequentialOnboardingView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Onboarding/SignatureView.swift
+++ b/Sources/Onboarding/SignatureView.swift
@@ -92,8 +92,10 @@ public struct SignatureView: View {
 }
 
 
+#if DEBUG
 struct SignatureView_Previews: PreviewProvider {
     static var previews: some View {
         SignatureView()
     }
 }
+#endif

--- a/Sources/Questionnaires/QuestionnaireView.swift
+++ b/Sources/Questionnaires/QuestionnaireView.swift
@@ -80,8 +80,10 @@ public struct QuestionnaireView: View {
 }
 
 
+#if DEBUG
 struct QuestionnaireView_Previews: PreviewProvider {
     static var previews: some View {
         QuestionnaireView(questionnaire: Questionnaire.dateTimeExample)
     }
 }
+#endif

--- a/Sources/Views/Drawing/CanvasView.swift
+++ b/Sources/Views/Drawing/CanvasView.swift
@@ -171,6 +171,7 @@ public struct CanvasView: View {
 }
 
 
+#if DEBUG
 struct SignatureView_Previews: PreviewProvider {
     @State private static var isDrawing = false
     
@@ -182,3 +183,4 @@ struct SignatureView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Views/Fields/NameFields.swift
+++ b/Sources/Views/Fields/NameFields.swift
@@ -126,6 +126,7 @@ public struct NameFields<FocusedField: Hashable>: View {
 }
 
 
+#if DEBUG
 struct NameFields_Previews: PreviewProvider {
     @State private static var name = PersonNameComponents()
     
@@ -134,3 +135,4 @@ struct NameFields_Previews: PreviewProvider {
         NameFields(name: $name)
     }
 }
+#endif

--- a/Sources/Views/ProfileView/UserProfileView.swift
+++ b/Sources/Views/ProfileView/UserProfileView.swift
@@ -62,6 +62,7 @@ public struct UserProfileView: View {
 }
 
 
+#if DEBUG
 struct ProfilePictureView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 16) {
@@ -95,3 +96,4 @@ struct ProfilePictureView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/Views/SwiftUIHelper/DescriptionGridRow.swift
+++ b/Sources/Views/SwiftUIHelper/DescriptionGridRow.swift
@@ -42,6 +42,7 @@ public struct DescriptionGridRow<Description: View, Content: View>: View {
 }
 
 
+#if DEBUG
 struct DescriptionGridRow_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
@@ -83,3 +84,4 @@ struct DescriptionGridRow_Previews: PreviewProvider {
             .background(Color(.systemGroupedBackground))
     }
 }
+#endif

--- a/Sources/Views/Text/LazyText.swift
+++ b/Sources/Views/Text/LazyText.swift
@@ -1,0 +1,59 @@
+//
+// This source file is part of the Stanford CardinalKit Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+/// <#Description#>
+public struct LazyText: View {
+    private let text: String
+    @State private var lines: [(linenumber: Int, text: String)] = []
+    
+    
+    public var body: some View {
+        LazyVStack(alignment: .leading) {
+            ForEach(lines, id: \.linenumber) { line in
+                Text(line.text)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+            .onAppear {
+                var lineNumber = 0
+                text.enumerateLines { line, _ in
+                    lines.append((lineNumber, line))
+                    lineNumber += 1
+                }
+            }
+    }
+    
+    
+    /// <#Description#>
+    /// - Parameter text: <#text description#>
+    public init(text: String) {
+        self.text = text
+    }
+}
+
+
+#if DEBUG
+struct LazyText_Previews: PreviewProvider {
+    static var previews: some View {
+        ScrollView {
+            LazyText(
+                text: """
+                This is a long text ...
+                
+                And some more lines ...
+                
+                And a third line ...
+                """
+            )
+        }
+    }
+}
+#endif

--- a/Sources/Views/Text/LazyText.swift
+++ b/Sources/Views/Text/LazyText.swift
@@ -9,7 +9,9 @@
 import SwiftUI
 
 
-/// <#Description#>
+/// A lazy loading text view that is especially useful for larger text files that should not be displayed all at once.
+///
+/// Uses a `LazyVStack` under the hood to load and display the text line-by-line.
 public struct LazyText: View {
     private let text: String
     @State private var lines: [(linenumber: Int, text: String)] = []
@@ -32,8 +34,8 @@ public struct LazyText: View {
     }
     
     
-    /// <#Description#>
-    /// - Parameter text: <#text description#>
+    /// A lazy loading text view that is especially useful for larger text files that should not be displayed all at once.
+    /// - Parameter text: The text that should be displayed in the ``LazyText`` view.
     public init(text: String) {
         self.text = text
     }

--- a/Sources/Views/Text/LazyText.swift
+++ b/Sources/Views/Text/LazyText.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford CardinalKit Template Application project
+// This source file is part of the CardinalKit open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/Sources/Views/Text/MarkdownView.swift
+++ b/Sources/Views/Text/MarkdownView.swift
@@ -110,8 +110,10 @@ public struct MarkdownView<Header: View, Footer: View>: View {
 }
 
 
+#if DEBUG
 struct PrivacyPolicyView_Previews: PreviewProvider {
     static var previews: some View {
         MarkdownView(markdown: Data())
     }
 }
+#endif

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-#if DEBUG
+#if DEBUG || TEST
 import Foundation
 
 

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertionInjector.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertionInjector.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-#if DEBUG
+#if DEBUG || TEST
 import Foundation
 
 

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-#if DEBUG
+#if DEBUG || TEST
 import Foundation
 
 

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable import Account
+import Account
 import CardinalKit
 import SwiftUI
 import Views
@@ -55,6 +55,7 @@ struct AccountTestsView: View {
 }
 
 
+#if DEBUG
 struct AccountTestsView_Previews: PreviewProvider {
     @StateObject private static var account: Account = {
         let accountServices: [any AccountService] = [
@@ -72,3 +73,4 @@ struct AccountTestsView_Previews: PreviewProvider {
             .environmentObject(account)
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ContactsTests/ContactsTestsView.swift
+++ b/Tests/UITests/TestApp/ContactsTests/ContactsTestsView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 
 struct ContactsTestsView: View {
-    static let mock: Contact = Contact(
+    static let mock = Contact(
         name: PersonNameComponents(givenName: "Paul", familyName: "Schmiedmayer"),
         image: Image(systemName: "figure.wave.circle"),
         title: "A Title",

--- a/Tests/UITests/TestApp/ContactsTests/ContactsTestsView.swift
+++ b/Tests/UITests/TestApp/ContactsTests/ContactsTestsView.swift
@@ -7,23 +7,53 @@
 //
 
 import CardinalKit
-@testable import Contact
+import Contact
 import SwiftUI
 
 
 struct ContactsTestsView: View {
+    static let mock: Contact = Contact(
+        name: PersonNameComponents(givenName: "Paul", familyName: "Schmiedmayer"),
+        image: Image(systemName: "figure.wave.circle"),
+        title: "A Title",
+        description: """
+        This is a description of a contact that will be displayed. It might even be longer than what has to be displayed in the contact card.
+        Why is this text so long, how much can you tell about one person?
+        """,
+        organization: "Stanford University",
+        address: {
+            let address = CNMutablePostalAddress()
+            address.country = "USA"
+            address.state = "CA"
+            address.postalCode = "94305"
+            address.city = "Stanford"
+            address.street = "450 Serra Mall"
+            return address
+        }(),
+        contactOptions: [
+            .call("+1 (234) 567-891"),
+            .call("+1 (234) 567-892"),
+            .text("+1 (234) 567-893"),
+            .email(addresses: ["lelandstanford@stanford.edu"], subject: "Hi Leland!"),
+            ContactOption(image: Image(systemName: "icloud.fill"), title: "Cloud", action: { })
+        ]
+    )
+    
+    
     var body: some View {
-        ContactsList(contacts: [ContactView_Previews.mock, ContactView_Previews.mock])
+        ContactsList(contacts: [ContactsTestsView.mock, ContactsTestsView.mock])
             .navigationTitle("Contacts")
             .background(Color(.systemGroupedBackground))
     }
 }
 
 
+#if DEBUG
 struct ContactsTestsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
-            ContactsList(contacts: [ContactView_Previews.mock, ContactView_Previews.mock, ContactView_Previews.mock])
+            ContactsList(contacts: [ContactsTestsView.mock, ContactsTestsView.mock, ContactsTestsView.mock])
         }
     }
 }
+#endif

--- a/Tests/UITests/TestApp/FHIRMockDataStorageProviderTests/FHIRMockDataStorageProviderTestsView.swift
+++ b/Tests/UITests/TestApp/FHIRMockDataStorageProviderTests/FHIRMockDataStorageProviderTestsView.swift
@@ -1,0 +1,41 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import HealthKitDataSource
+import FHIR
+import FHIRMockDataStorageProvider
+import SwiftUI
+
+
+struct FHIRMockDataStorageProviderTestsView: View {
+    @EnvironmentObject var healthKitComponent: HealthKit<FHIR>
+    
+    
+    var body: some View {
+        MockUploadList()
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Authorize") {
+                        _Concurrency.Task {
+                            try await healthKitComponent.askForAuthorization()
+                        }
+                    }
+                }
+            }
+    }
+}
+
+
+#if DEBUG
+struct FHIRMockDataStorageProviderTestsView_Previews: PreviewProvider {
+    static var previews: some View {
+        FHIRMockDataStorageProviderTestsView()
+    }
+}
+#endif

--- a/Tests/UITests/TestApp/FHIRMockDataStorageProviderTests/FHIRMockDataStorageProviderTestsView.swift
+++ b/Tests/UITests/TestApp/FHIRMockDataStorageProviderTests/FHIRMockDataStorageProviderTestsView.swift
@@ -7,9 +7,9 @@
 //
 
 import CardinalKit
-import HealthKitDataSource
 import FHIR
 import FHIRMockDataStorageProvider
+import HealthKitDataSource
 import SwiftUI
 
 

--- a/Tests/UITests/TestApp/FirestoreDataStorageTests/FirestoreDataStorageTests.swift
+++ b/Tests/UITests/TestApp/FirestoreDataStorageTests/FirestoreDataStorageTests.swift
@@ -7,7 +7,7 @@
 //
 
 import CardinalKit
-@testable import FirestoreDataStorage
+import FirestoreDataStorage
 import SwiftUI
 
 
@@ -91,6 +91,7 @@ struct FirestoreDataStorageTestsView: View {
 }
 
 
+#if DEBUG
 struct FirebaseDataStorageTestsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
@@ -98,3 +99,4 @@ struct FirebaseDataStorageTestsView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
+++ b/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
@@ -7,7 +7,7 @@
 //
 
 import CryptoKit
-@testable import LocalStorage
+import LocalStorage
 import SecureStorage
 import XCTRuntimeAssertions
 

--- a/Tests/UITests/TestApp/OnboardingTests/OnboardingTestsView.swift
+++ b/Tests/UITests/TestApp/OnboardingTests/OnboardingTestsView.swift
@@ -7,7 +7,7 @@
 //
 
 import CardinalKit
-@testable import Onboarding
+import Onboarding
 import SwiftUI
 
 
@@ -95,6 +95,7 @@ struct OnboardingTestsView: View {
 }
 
 
+#if DEBUG
 struct OnboardingTestsView_Previews: PreviewProvider {
     @State private static var path = NavigationPath()
     
@@ -105,3 +106,4 @@ struct OnboardingTestsView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
+++ b/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable import CardinalKit
+import CardinalKit
 import CryptoKit
 import Foundation
 import SecureStorage
@@ -25,7 +25,6 @@ final class SecureStorageTests: TestAppTestCase {
     func runTests() async throws {
         try testCredentials()
         try testInternetCredentials()
-        try testCredentialsNotWorkingWithSecureEnclave()
         try testKeys()
     }
     
@@ -74,14 +73,6 @@ final class SecureStorageTests: TestAppTestCase {
         
         try secureStorage.deleteCredentials("@CardinalKit", server: "stanford.edu")
         try XCTAssertNil(try secureStorage.retrieveCredentials("@CardinalKit", server: "stanford.edu"))
-    }
-    
-    func testCredentialsNotWorkingWithSecureEnclave() throws {
-        let serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
-
-        try XCTRuntimeAssertion {
-            try self.secureStorage.store(credentials: serverCredentials, server: "twitter.com")
-        }
     }
     
     func testKeys() throws {

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -12,8 +12,8 @@ import FHIRMockDataStorageProvider
 import FirebaseAccount
 import FirestoreDataStorage
 @preconcurrency import HealthKit
-import HealthKitToFHIRAdapter
 import HealthKitDataSource
+import HealthKitToFHIRAdapter
 import LocalStorage
 import SecureStorage
 import SwiftUI

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -7,9 +7,12 @@
 //
 
 import CardinalKit
+@preconcurrency import FHIR
+import FHIRMockDataStorageProvider
 import FirebaseAccount
 import FirestoreDataStorage
 @preconcurrency import HealthKit
+import HealthKitToFHIRAdapter
 import HealthKitDataSource
 import LocalStorage
 import SecureStorage
@@ -18,20 +21,36 @@ import SwiftUI
 
 class TestAppDelegate: CardinalKitAppDelegate {
     override var configuration: Configuration {
-        Configuration(standard: TestAppStandard()) {
-            Firestore(settings: .emulator)
-            if CommandLine.arguments.contains("--firebaseAccount") {
-                FirebaseAccountConfiguration(emulatorSettings: (host: "localhost", port: 9099))
-            } else {
-                TestAccountConfiguration()
+        if CommandLine.arguments.contains("--fhirTests") {
+            return Configuration(standard: FHIR()) {
+                MockDataStorageProvider()
+                if HKHealthStore.isHealthDataAvailable() {
+                    HealthKit {
+                        CollectSample(
+                            HKQuantityType(.stepCount),
+                            deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
+                        )
+                    } adapter: {
+                        HealthKitToFHIRAdapter()
+                    }
+                }
             }
-            if HKHealthStore.isHealthDataAvailable() {
-                healthKit
+        } else {
+            return Configuration(standard: TestAppStandard()) {
+                Firestore(settings: .emulator)
+                if CommandLine.arguments.contains("--firebaseAccount") {
+                    FirebaseAccountConfiguration(emulatorSettings: (host: "localhost", port: 9099))
+                } else {
+                    TestAccountConfiguration()
+                }
+                if HKHealthStore.isHealthDataAvailable() {
+                    healthKit
+                }
+                LocalStorage()
+                MultipleObservableObjectsTestsComponent()
+                ObservableComponentTestsComponent(message: "Passed")
+                SecureStorage()
             }
-            LocalStorage()
-            MultipleObservableObjectsTestsComponent()
-            ObservableComponentTestsComponent(message: "Passed")
-            SecureStorage()
         }
     }
     

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -32,6 +32,8 @@ struct UITestsApp: App {
         @MainActor
         @ViewBuilder
         func view(withNavigationPath path: Binding<NavigationPath>) -> some View {
+            // swiftlint:disable:previous cyclomatic_complexity
+            // The function has a higher cyclomatic complexity because we want to display all possible tests in a single switch statement
             switch self {
             case .account:
                 AccountTestsView()

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -14,6 +14,7 @@ struct UITestsApp: App {
     enum Tests: String, CaseIterable, Identifiable {
         case account = "Account"
         case contacts = "Contacts"
+        case fhirMockDataStorageProvider = "FHIRMockDataStorageProvider"
         case firebaseAccount = "FirebaseAccount"
         case firestoreDataStorage = "FirestoreDataStorage"
         case healthKit = "HealthKit"
@@ -36,6 +37,8 @@ struct UITestsApp: App {
                 AccountTestsView()
             case .contacts:
                 ContactsTestsView()
+            case .fhirMockDataStorageProvider:
+                FHIRMockDataStorageProviderTestsView()
             case .firebaseAccount:
                 FirebaseAccountTestsView()
             case .firestoreDataStorage:

--- a/Tests/UITests/TestApp/ViewsTests/CanvasTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/CanvasTestView.swift
@@ -42,8 +42,10 @@ struct CanvasTestView: View {
 }
 
 
+#if DEBUG
 struct CanvasTestView_Previews: PreviewProvider {
     static var previews: some View {
         CanvasTestView()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/GeometryReaderTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/GeometryReaderTestView.swift
@@ -41,8 +41,10 @@ struct GeometryReaderTestView: View {
 }
 
 
+#if DEBUG
 struct GeometryReaderTestView_Previews: PreviewProvider {
     static var previews: some View {
         GeometryReaderTestView()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/MarkdownViewTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/MarkdownViewTestView.swift
@@ -34,8 +34,10 @@ struct MarkdownViewTestView: View {
 }
 
 
+#if DEBUG
 struct MarkdownViewTestView_Previews: PreviewProvider {
     static var previews: some View {
         MarkdownViewTestView()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/NameFieldsTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/NameFieldsTestView.swift
@@ -30,8 +30,10 @@ struct NameFieldsTestView: View {
 }
 
 
+#if DEBUG
 struct NameFieldsTestView_Previews: PreviewProvider {
     static var previews: some View {
         NameFieldsTestView()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/ViewStateTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ViewStateTestView.swift
@@ -42,8 +42,10 @@ struct ViewStateTestView: View {
 }
 
 
+#if DEBUG
 struct ViewStateTestView_Previews: PreviewProvider {
     static var previews: some View {
         ViewStateTestView()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/ViewsTestsView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ViewsTestsView.swift
@@ -17,6 +17,7 @@ struct ViewsTestsView: View {
         case userProfile = "User Profile"
         case geometryReader = "Geometry Reader"
         case label = "Label"
+        case lazyText = "Lazy Text"
         case markdownView = "Markdown View"
         case viewState = "View State"
     }
@@ -42,6 +43,8 @@ struct ViewsTestsView: View {
                     geometryReader
                 case .label:
                     label
+                case .lazyText:
+                    lazyText
                 case .markdownView:
                     markdownView
                 case .viewState:
@@ -107,6 +110,21 @@ struct ViewsTestsView: View {
     @ViewBuilder
     private var markdownView: some View {
         MarkdownViewTestView()
+    }
+    
+    @ViewBuilder
+    private var lazyText: some View {
+        ScrollView {
+            LazyText(
+                text: """
+                This is a long text ...
+                
+                And some more lines ...
+                
+                And a third line ...
+                """
+            )
+        }
     }
     
     @ViewBuilder

--- a/Tests/UITests/TestApp/ViewsTests/ViewsTestsView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ViewsTestsView.swift
@@ -121,6 +121,7 @@ struct ViewsTestsView: View {
 }
 
 
+#if DEBUG
 struct ViewsTestsView_Previews: PreviewProvider {
     @State private static var path = NavigationPath()
     
@@ -131,3 +132,4 @@ struct ViewsTestsView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
+++ b/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
@@ -12,7 +12,7 @@ import XCTHealthKit
 
 
 final class FHIRMockDataStorageProviderTests: TestAppUITests {
-    func testHealthKit() throws { // swiftlint:disable:this function_body_length
+    func testFHIRMockDataStorageProviderTests() throws {
         let app = XCUIApplication()
         app.launchArguments = ["--fhirTests"]
         app.deleteAndLaunch(withSpringboardAppName: "TestApp")

--- a/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
+++ b/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
@@ -1,0 +1,53 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+import XCTestExtensions
+import XCTHealthKit
+
+
+final class FHIRMockDataStorageProviderTests: TestAppUITests {
+    func testHealthKit() throws { // swiftlint:disable:this function_body_length
+        let app = XCUIApplication()
+        app.launchArguments = ["--fhirTests"]
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+        
+        app.activate()
+        app.buttons["FHIRMockDataStorageProvider"].tap()
+        XCTAssert(app.buttons["Authorize"].waitForExistence(timeout: 2))
+        app.buttons["Authorize"].tap()
+        try app.handleHealthKitAuthorization()
+        
+        try assertObservationCellPresent(false)
+        
+        try exitAppAndOpenHealth(.steps)
+        app.activate()
+        
+        sleep(5)
+        
+        try assertObservationCellPresent(true, pressIfPresent: true)
+        try assertObservationCellPresent(true, pressIfPresent: false)
+    }
+    
+    
+    private func assertObservationCellPresent(_ shouldBePresent: Bool, pressIfPresent: Bool = true) throws {
+        let app = XCUIApplication()
+        
+        let observationText = "/Observation/"
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", observationText)
+        
+        if shouldBePresent {
+            XCTAssertTrue(app.staticTexts.containing(predicate).firstMatch.waitForExistence(timeout: 5))
+            if pressIfPresent {
+                app.staticTexts.containing(predicate).firstMatch.tap()
+            }
+        } else {
+            XCTAssertFalse(app.staticTexts.containing(predicate).firstMatch.waitForExistence(timeout: 5))
+        }
+    }
+}

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -100,6 +100,18 @@ final class ViewsTests: TestAppUITests {
         XCTAssertEqual(app.staticTexts.allElementsBoundByIndex.filter { $0.label.contains(text) }.count, 2)
     }
     
+    func testLazyText() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        app.collectionViews.buttons["Views"].tap()
+        app.collectionViews.buttons["Lazy Text"].tap()
+        
+        XCTAssert(app.staticTexts["This is a long text ..."].exists)
+        XCTAssert(app.staticTexts["And some more lines ..."].exists)
+        XCTAssert(app.staticTexts["And a third line ..."].exists)
+    }
+    
     func testMardownView() throws {
         let app = XCUIApplication()
         app.launch()

--- a/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
+++ b/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
@@ -9,14 +9,11 @@
     }
   ],
   "defaultOptions" : {
-    "maximumTestRepetitions" : 2,
-    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:UITests.xcodeproj",
       "identifier" : "2F6D139128F5F384007C25D6",
       "name" : "TestApp"
-    },
-    "testRepetitionMode" : "retryOnFailure"
+    }
   },
   "testTargets" : [
     {

--- a/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
+++ b/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
@@ -17,6 +17,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "HealthKitTests"
+      ],
       "target" : {
         "containerPath" : "container:UITests.xcodeproj",
         "identifier" : "2F6D13AB28F5F386007C25D6",

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -579,124 +579,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		2F36AD28299DB08C00B1077C /* Test */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				ENABLE_TESTING_SEARCH_PATHS = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TEST;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = Test;
-		};
-		2F36AD29299DB08C00B1077C /* Test */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 637867499T;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = TestApp/Info.plist;
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.testapp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Test;
-		};
-		2F36AD2A299DB08C00B1077C /* Test */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 637867499T;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = TestAppUITests/Info.plist;
-				INFOPLIST_KEY_LSApplicationCategoryType = "";
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.testappuitests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = TestApp;
-			};
-			name = Test;
-		};
 		2F6D13B428F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -934,7 +816,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B428F5F386007C25D6 /* Debug */,
-				2F36AD28299DB08C00B1077C /* Test */,
 				2F6D13B528F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -944,7 +825,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B728F5F386007C25D6 /* Debug */,
-				2F36AD29299DB08C00B1077C /* Test */,
 				2F6D13B828F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -954,7 +834,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13BD28F5F386007C25D6 /* Debug */,
-				2F36AD2A299DB08C00B1077C /* Test */,
 				2F6D13BE28F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		2F1B82092942DE390037BC09 /* TestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1B82082942DE390037BC09 /* TestAppUITests.swift */; };
 		2F2A354F291CCF74000E8373 /* TestAppHealthKitAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2A354E291CCF74000E8373 /* TestAppHealthKitAdapter.swift */; };
 		2F2E4B8429749C5900FF710F /* FirestoreDataStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2E4B8329749C5900FF710F /* FirestoreDataStorageTests.swift */; };
+		2F36AD2C299DB0CC00B1077C /* FHIRMockDataStorageProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 2F36AD2B299DB0CC00B1077C /* FHIRMockDataStorageProvider */; };
+		2F36AD2F299DB11D00B1077C /* FHIRMockDataStorageProviderTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F36AD2E299DB11D00B1077C /* FHIRMockDataStorageProviderTestsView.swift */; };
+		2F36AD31299DB69F00B1077C /* HealthKitToFHIRAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2F36AD30299DB69F00B1077C /* HealthKitToFHIRAdapter */; };
+		2F36AD33299DB72400B1077C /* FHIRMockDataStorageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F36AD32299DB72400B1077C /* FHIRMockDataStorageProviderTests.swift */; };
 		2F4530C4293FD704000A858F /* AccountTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4530C3293FD704000A858F /* AccountTestsView.swift */; };
 		2F4D91752948EA1A000E2D94 /* ContactsTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D91742948EA1A000E2D94 /* ContactsTestsView.swift */; };
 		2F4D91772948EB33000E2D94 /* ContactsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D91762948EB33000E2D94 /* ContactsTests.swift */; };
@@ -90,6 +94,8 @@
 		2F1B82082942DE390037BC09 /* TestAppUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAppUITests.swift; sourceTree = "<group>"; };
 		2F2A354E291CCF74000E8373 /* TestAppHealthKitAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppHealthKitAdapter.swift; sourceTree = "<group>"; };
 		2F2E4B8329749C5900FF710F /* FirestoreDataStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreDataStorageTests.swift; sourceTree = "<group>"; };
+		2F36AD2E299DB11D00B1077C /* FHIRMockDataStorageProviderTestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRMockDataStorageProviderTestsView.swift; sourceTree = "<group>"; };
+		2F36AD32299DB72400B1077C /* FHIRMockDataStorageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRMockDataStorageProviderTests.swift; sourceTree = "<group>"; };
 		2F4530C3293FD704000A858F /* AccountTestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTestsView.swift; sourceTree = "<group>"; };
 		2F4D91742948EA1A000E2D94 /* ContactsTestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsTestsView.swift; sourceTree = "<group>"; };
 		2F4D91762948EB33000E2D94 /* ContactsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsTests.swift; sourceTree = "<group>"; };
@@ -148,6 +154,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FC94CDC298B57E0009C8209 /* FirebaseAccount in Frameworks */,
+				2F36AD31299DB69F00B1077C /* HealthKitToFHIRAdapter in Frameworks */,
 				2F4F0390294A66FB0062D4C7 /* LocalStorage in Frameworks */,
 				2F4F0394294A66FB0062D4C7 /* SecureStorage in Frameworks */,
 				2F8CC7D8294D2B6A00358B7E /* Scheduler in Frameworks */,
@@ -157,6 +164,7 @@
 				2F4F0392294A66FB0062D4C7 /* Onboarding in Frameworks */,
 				2F148BFD298BADD700031B7F /* FirebaseConfiguration in Frameworks */,
 				2F4F0386294A66FB0062D4C7 /* Account in Frameworks */,
+				2F36AD2C299DB0CC00B1077C /* FHIRMockDataStorageProvider in Frameworks */,
 				2F4F0396294A66FB0062D4C7 /* XCTRuntimeAssertions in Frameworks */,
 				2F4F0388294A66FB0062D4C7 /* CardinalKit in Frameworks */,
 				2FB926E32974AF15008E7B03 /* FirestoreDataStorage in Frameworks */,
@@ -182,6 +190,14 @@
 				2F148BFF298BB15900031B7F /* FirebaseAccountTestsView.swift */,
 			);
 			path = FirebaseAccountTests;
+			sourceTree = "<group>";
+		};
+		2F36AD2D299DB0FF00B1077C /* FHIRMockDataStorageProviderTests */ = {
+			isa = PBXGroup;
+			children = (
+				2F36AD2E299DB11D00B1077C /* FHIRMockDataStorageProviderTestsView.swift */,
+			);
+			path = FHIRMockDataStorageProviderTests;
 			sourceTree = "<group>";
 		};
 		2F4530C0293FD617000A858F /* AccountTests */ = {
@@ -240,6 +256,7 @@
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2F4530C0293FD617000A858F /* AccountTests */,
 				2F4D91732948E9F1000E2D94 /* ContactsTests */,
+				2F36AD2D299DB0FF00B1077C /* FHIRMockDataStorageProviderTests */,
 				2F148BFE298BB14100031B7F /* FirebaseAccountTests */,
 				2FE62C3B2966071400FCBE7F /* FirestoreDataStorageTests */,
 				2FC2C404291D848600712676 /* HealthKitTests */,
@@ -266,6 +283,7 @@
 				2FA04AD62943165200648A48 /* AccountResetPasswordTests.swift */,
 				2FC246D52941720600F75383 /* AccountSignUpTests.swift */,
 				2F4D91762948EB33000E2D94 /* ContactsTests.swift */,
+				2F36AD32299DB72400B1077C /* FHIRMockDataStorageProviderTests.swift */,
 				2F8CE160298C2C6D003799A8 /* FirebaseAccountTests.swift */,
 				2F2E4B8329749C5900FF710F /* FirestoreDataStorageTests.swift */,
 				2FC2C407291DCC8200712676 /* HealthKitTests.swift */,
@@ -397,6 +415,8 @@
 				2FB926E22974AF15008E7B03 /* FirestoreDataStorage */,
 				2FC94CDB298B57E0009C8209 /* FirebaseAccount */,
 				2F148BFC298BADD700031B7F /* FirebaseConfiguration */,
+				2F36AD2B299DB0CC00B1077C /* FHIRMockDataStorageProvider */,
+				2F36AD30299DB69F00B1077C /* HealthKitToFHIRAdapter */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -496,6 +516,7 @@
 				2F8A43222913172E005D2B8F /* ObservableComponentTestsComponent.swift in Sources */,
 				2FC246C82941376600F75383 /* MultipleObservableObjectsTestsComponent.swift in Sources */,
 				2F7B6CAD294BCA6F00FDC494 /* GeometryReaderTestView.swift in Sources */,
+				2F36AD2F299DB11D00B1077C /* FHIRMockDataStorageProviderTestsView.swift in Sources */,
 				2F7B6CB3294BCA8200FDC494 /* ViewStateTestView.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				2FE62C3D2966074F00FCBE7F /* FirestoreDataStorageTests.swift in Sources */,
@@ -542,6 +563,7 @@
 				2FB77BA52910F84D009FDDE2 /* LocalStorageTests.swift in Sources */,
 				2FE122B2294247480016B162 /* XCUIApplication+TextEntry.swift in Sources */,
 				2FC2C408291DCC8200712676 /* HealthKitTests.swift in Sources */,
+				2F36AD33299DB72400B1077C /* FHIRMockDataStorageProviderTests.swift in Sources */,
 				2FD6390C294B0A4B008BADFC /* OnboardingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -557,6 +579,124 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		2F36AD28299DB08C00B1077C /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TEST;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Test;
+		};
+		2F36AD29299DB08C00B1077C /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = 637867499T;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TestApp/Info.plist;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.testapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Test;
+		};
+		2F36AD2A299DB08C00B1077C /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 637867499T;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TestAppUITests/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.testappuitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = TestApp;
+			};
+			name = Test;
+		};
 		2F6D13B428F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -593,6 +733,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -653,6 +794,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -682,7 +824,6 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TestApp/Info.plist;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
@@ -719,7 +860,6 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TestApp/Info.plist;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
@@ -794,6 +934,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B428F5F386007C25D6 /* Debug */,
+				2F36AD28299DB08C00B1077C /* Test */,
 				2F6D13B528F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -803,6 +944,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B728F5F386007C25D6 /* Debug */,
+				2F36AD29299DB08C00B1077C /* Test */,
 				2F6D13B828F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -812,6 +954,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13BD28F5F386007C25D6 /* Debug */,
+				2F36AD2A299DB08C00B1077C /* Test */,
 				2F6D13BE28F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -842,6 +985,14 @@
 		2F148BFC298BADD700031B7F /* FirebaseConfiguration */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FirebaseConfiguration;
+		};
+		2F36AD2B299DB0CC00B1077C /* FHIRMockDataStorageProvider */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FHIRMockDataStorageProvider;
+		};
+		2F36AD30299DB69F00B1077C /* HealthKitToFHIRAdapter */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = HealthKitToFHIRAdapter;
 		};
 		2F4F0385294A66FB0062D4C7 /* Account */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Test"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"


### PR DESCRIPTION
# FHIR Mock Data Storage Provider

## :recycle: Current situation & Problem
- Currently is is not easy to observe the inner workings of the `FHIR` standard in a `CardinalKit`-based application.

## :bulb: Proposed solution
- This PR adds the FHIR Mock Data Storage Provider that enables an easy representation of the data collected by the FHIR standard in a CardinalKit-based API.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

