### PR TITLE
Fix Swift Package Index Build Error

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -10,12 +10,19 @@ version: 1
 builder:
   configs:
     - platform: ios
+      scheme: CardinalKit
       documentation_targets:
       - CardinalKit
       - Account
       - Contact
       - FHIR
+      - FHIRMockDataStorageProvider
+      - FirestoreDataStorage
+      - FirestoreStoragePrefixUserIdAdapter
+      - FirebaseConfiguration
+      - FirebaseAccount
       - HealthKitDataSource
+      - HealthKitToFHIRAdapter
       - LocalStorage
       - Onboarding
       - Scheduler


### PR DESCRIPTION
# Fix Swift Package Index Build Error

## :recycle: Current situation & Problem
As described in https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2261#issuecomment-1432749265 we are currently encountering an error for our [CardinalKit](https://swiftpackageindex.com/StanfordBDHG/CardinalKit) project: https://swiftpackageindex.com/builds/501AD011-0145-48C2-8D83-A286EF4D4683. The build error indicates that the CardinalKit-Package scheme is not present.

## :bulb: Proposed solution
As pointed out by @finestructure in https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2261#issuecomment-1432749265 explicitly stating the scheme should fix the error.

### Related PRs
Closes #49 as I am not able to make the changes in the forked branch to update it to the latest version of main and then merge it. Thank you for the fix @ finestructure!!

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

