### PR TITLE
Improve API Surface for the Account Module

### DIFF
--- a/Sources/Account/Username and Password/Sign Up/SignUpValues.swift
+++ b/Sources/Account/Username and Password/Sign Up/SignUpValues.swift
@@ -29,7 +29,7 @@ public struct SignUpValues: Sendable {
     ///   - name: The name as inputted in the sign-up user interface.
     ///   - genderIdentity: The self-identified gender as inputted in the sign-up user interface.
     ///   - dateOfBirth: The date of birth as inputted in the sign-up user interface.
-    init(username: String, password: String, name: PersonNameComponents, genderIdentity: GenderIdentity?, dateOfBirth: Date?) {
+    public init(username: String, password: String, name: PersonNameComponents, genderIdentity: GenderIdentity?, dateOfBirth: Date?) {
         self.username = username
         self.password = password
         self.name = name


### PR DESCRIPTION
# Improve API Surface for the Account Module

## :recycle: Current situation & Problem
Project that want to provide a custom Sign Up experience currently can not rely on the `SignUpValues` type as the initializer was not made public. 

## :bulb: Proposed solution
This PR fixes this small oversight and makes the `SignUpValues` initializer public.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

