### PR TITLE
Make name localization in onboarding configurable

### DIFF
--- a/Sources/Account/Resources/en.lproj/Localizable.strings
+++ b/Sources/Account/Resources/en.lproj/Localizable.strings
@@ -33,10 +33,10 @@
 Password";
 "UAP_SIGNUP_PASSWORD_REPEAT_PLACEHOLDER" = "Repeat your password ...";
 "UAP_SIGNUP_PASSWORD_NOT_EQUAL_ERROR" = "The entered passwords are not equal.";
-"UAP_SIGNUP_GIVEN_NAME_TITLE" = "Given Name";
-"UAP_SIGNUP_GIVEN_NAME_PLACEHOLDER" = "Enter your given name ...";
-"UAP_SIGNUP_FAMILY_NAME_TITLE" = "Family Name";
-"UAP_SIGNUP_FAMILY_NAME_PLACEHOLDER" = "Enter your family name ...";
+"UAP_SIGNUP_GIVEN_NAME_TITLE" = "First Name";
+"UAP_SIGNUP_GIVEN_NAME_PLACEHOLDER" = "Enter your first name ...";
+"UAP_SIGNUP_FAMILY_NAME_TITLE" = "Last Name";
+"UAP_SIGNUP_FAMILY_NAME_PLACEHOLDER" = "Enter your last name ...";
 "UAP_SIGNUP_GENDER_IDENTITY_TITLE" = "Gender Identity";
 "UAP_SIGNUP_DATE_OF_BIRTH_TITLE" = "Date of Birth";
 "UAP_SIGNUP_ACTION_BUTTON_TITLE" = "Sign Up";

--- a/Sources/Onboarding/ConsentView.swift
+++ b/Sources/Onboarding/ConsentView.swift
@@ -63,8 +63,8 @@ public struct ConsentView<ContentView: View, Action: View>: View {
                         Divider()
                         NameFields(
                             name: $name,
-                            givenNameField: LocalizationDefaults.givenName,
-                            familyNameField: LocalizationDefaults.familyName
+                            givenNameField: givenNameField,
+                            familyNameField: familyNameField
                         )
                         if showSignatureView {
                             Divider()
@@ -106,11 +106,15 @@ public struct ConsentView<ContentView: View, Action: View>: View {
     ///   - asyncMarkdown: The markdown content provided as an UTF8 encoded `Data` instance that can be provided asynchronously.
     ///   - footer: The footer view will be displayed above the markdown content.
     ///   - action: The action that should be performed once the consent has been given.
+    ///   - givenNameField: The localization to use for the given (first) name field
+    ///   - familyNameField: The localization to use for the family (last) name field
     public init(
         @ViewBuilder header: () -> (some View) = { EmptyView() },
         asyncMarkdown: @escaping () async -> Data,
         @ViewBuilder footer: () -> (some View) = { EmptyView() },
-        action: @escaping () -> Void
+        action: @escaping () -> Void,
+        givenNameField: FieldLocalization = LocalizationDefaults.givenName,
+        familyNameField: FieldLocalization = LocalizationDefaults.familyName
     ) where ContentView == MarkdownView<AnyView, AnyView>, Action == OnboardingActionsView {
         self.init(
             contentView: {
@@ -124,7 +128,9 @@ public struct ConsentView<ContentView: View, Action: View>: View {
                 OnboardingActionsView(String(localized: "CONSENT_ACTION", bundle: .module)) {
                     action()
                 }
-            }
+            },
+            givenNameField: givenNameField,
+            familyNameField: familyNameField
         )
     }
 
@@ -132,6 +138,8 @@ public struct ConsentView<ContentView: View, Action: View>: View {
     /// - Parameters:
     ///   - contentView: The content view providing context about the consent view.
     ///   - actionView: The action view that should be displayed under the name and signature boxes.
+    ///   - givenNameField: The localization to use for the given (first) name field
+    ///   - familyNameField: The localization to use for the family (last) name field
     public init(
         @ViewBuilder contentView: () -> (ContentView),
         @ViewBuilder actionView: () -> (Action),

--- a/Sources/Onboarding/ConsentView.swift
+++ b/Sources/Onboarding/ConsentView.swift
@@ -27,8 +27,25 @@ import Views
 /// )
 /// ```
 public struct ConsentView<ContentView: View, Action: View>: View {
+    public enum LocalizationDefaults {
+        public static var givenName: FieldLocalization {
+            FieldLocalization(
+                title: String(localized: "NAME_FIELD_GIVEN_NAME_TITLE", bundle: .module),
+                placeholder: String(localized: "NAME_FIELD_GIVEN_NAME_PLACEHOLDER", bundle: .module)
+            )
+        }
+        public static var familyName: FieldLocalization {
+            FieldLocalization(
+                title: String(localized: "NAME_FIELD_FAMILY_NAME_TITLE", bundle: .module),
+                placeholder: String(localized: "NAME_FIELD_FAMILY_NAME_PLACEHOLDER", bundle: .module)
+            )
+        }
+    }
+
     private let contentView: ContentView
     private let action: Action
+    private let givenNameField: FieldLocalization
+    private let familyNameField: FieldLocalization
     @State private var name = PersonNameComponents()
     @State private var showSignatureView = false
     @State private var isSigning = false
@@ -44,7 +61,11 @@ public struct ConsentView<ContentView: View, Action: View>: View {
                 actionView: {
                     VStack {
                         Divider()
-                        NameFields(name: $name)
+                        NameFields(
+                            name: $name,
+                            givenNameField: LocalizationDefaults.givenName,
+                            familyNameField: LocalizationDefaults.familyName
+                        )
                         if showSignatureView {
                             Divider()
                             SignatureView(signature: $signature, isSigning: $isSigning, name: name)
@@ -113,10 +134,14 @@ public struct ConsentView<ContentView: View, Action: View>: View {
     ///   - actionView: The action view that should be displayed under the name and signature boxes.
     public init(
         @ViewBuilder contentView: () -> (ContentView),
-        @ViewBuilder actionView: () -> (Action)
+        @ViewBuilder actionView: () -> (Action),
+        givenNameField: FieldLocalization = LocalizationDefaults.givenName,
+        familyNameField: FieldLocalization = LocalizationDefaults.familyName
     ) {
         self.contentView = contentView()
         self.action = actionView()
+        self.givenNameField = givenNameField
+        self.familyNameField = familyNameField
     }
 }
 

--- a/Sources/Onboarding/Resources/en.lproj/Localizable.strings
+++ b/Sources/Onboarding/Resources/en.lproj/Localizable.strings
@@ -16,3 +16,9 @@
 
 // MARK: Signature View
 "SIGNATURE_VIEW_UNDO" = "Undo";
+
+// MARK: Name Fields
+"NAME_FIELD_GIVEN_NAME_TITLE" = "First Name";
+"NAME_FIELD_GIVEN_NAME_PLACEHOLDER" = "Enter your first name ...";
+"NAME_FIELD_FAMILY_NAME_TITLE" = "Last Name";
+"NAME_FIELD_FAMILY_NAME_PLACEHOLDER" = "Enter your last name ...";

--- a/Sources/Views/Resources/en.lproj/Localizable.strings
+++ b/Sources/Views/Resources/en.lproj/Localizable.strings
@@ -10,10 +10,10 @@
 "VIEW_STATE_DEFAULT_ERROR_TITLE" = "Error";
 
 // MARK: Name Fields
-"NAME_FIELD_GIVEN_NAME_TITLE" = "Given Name";
-"NAME_FIELD_GIVEN_NAME_PLACEHOLDER" = "Enter your given name ...";
-"NAME_FIELD_FAMILY_NAME_TITLE" = "Family Name";
-"NAME_FIELD_FAMILY_NAME_PLACEHOLDER" = "Enter your family name ...";
+"NAME_FIELD_GIVEN_NAME_TITLE" = "First Name";
+"NAME_FIELD_GIVEN_NAME_PLACEHOLDER" = "Enter your first name ...";
+"NAME_FIELD_FAMILY_NAME_TITLE" = "Last Name";
+"NAME_FIELD_FAMILY_NAME_PLACEHOLDER" = "Enter your last name ...";
 
 // MARK: MarkdownView
 "MARKDOWN_LOADING_ERROR" = "Could not load and parse the document.";

--- a/Tests/UITests/TestApp/OnboardingTests/OnboardingTestsView.swift
+++ b/Tests/UITests/TestApp/OnboardingTests/OnboardingTestsView.swift
@@ -9,6 +9,7 @@
 import CardinalKit
 import Onboarding
 import SwiftUI
+import Views
 
 
 struct OnboardingTestsView: View {
@@ -38,8 +39,7 @@ struct OnboardingTestsView: View {
                 }
             }
     }
-    
-    
+
     private var consentView: some View {
         ConsentView(
             header: {
@@ -50,7 +50,17 @@ struct OnboardingTestsView: View {
             },
             action: {
                 path.append(OnboardingStep.onboardingView)
-            }
+            },
+            givenNameField:
+                FieldLocalization(
+                    title: "First Name",
+                    placeholder: "Enter your first name ..."
+                ),
+            familyNameField:
+                FieldLocalization(
+                    title: "Surname",
+                    placeholder: "Enter your surname ..."
+                )
         )
             .navigationBarTitleDisplayMode(.inline)
     }

--- a/Tests/UITests/TestAppUITests/AccountSignUpTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSignUpTests.swift
@@ -101,12 +101,12 @@ final class AccountSignUpTests: TestAppUITests {
         app.buttons["Male"].tap()
         app.testPrimaryButton(enabled: false, title: buttonTitle)
         
-        let givenNameField = "Enter your given name ..."
+        let givenNameField = "Enter your first name ..."
         let givenName = "Leland"
         app.textFields[givenNameField].enter(value: givenName)
         app.testPrimaryButton(enabled: false, title: buttonTitle)
         
-        let familyNameField = "Enter your family name ..."
+        let familyNameField = "Enter your last name ..."
         let familyName = "Stanford"
         app.textFields[familyNameField].enter(value: familyName)
         app.testPrimaryButton(enabled: true, title: buttonTitle)

--- a/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
@@ -275,9 +275,9 @@ extension XCUIApplication {
         
         swipeUp()
         
-        textFields["Enter your given name ..."].enter(value: givenName)
+        textFields["Enter your first name ..."].enter(value: givenName)
         swipeUp()
-        textFields["Enter your family name ..."].enter(value: familyName)
+        textFields["Enter your last name ..."].enter(value: familyName)
         swipeUp()
         
         

--- a/Tests/UITests/TestAppUITests/OnboardingTests.swift
+++ b/Tests/UITests/TestAppUITests/OnboardingTests.swift
@@ -30,8 +30,8 @@ final class OnboardingTests: TestAppUITests {
             throw XCTSkip("PKCanvas view-related tests are currently skipped on Intel-based iOS simulators due to a metal bug on the simulator.")
         #endif
         
-        app.textFields["Enter your given name ..."].enter(value: "Leland")
-        app.textFields["Enter your family name ..."].enter(value: "Stanford")
+        app.textFields["Enter your first name ..."].enter(value: "Leland")
+        app.textFields["Enter your last name ..."].enter(value: "Stanford")
         
         hitConsentButton(app)
         

--- a/Tests/UITests/TestAppUITests/OnboardingTests.swift
+++ b/Tests/UITests/TestAppUITests/OnboardingTests.swift
@@ -31,7 +31,7 @@ final class OnboardingTests: TestAppUITests {
         #endif
         
         app.textFields["Enter your first name ..."].enter(value: "Leland")
-        app.textFields["Enter your last name ..."].enter(value: "Stanford")
+        app.textFields["Enter your surname ..."].enter(value: "Stanford")
         
         hitConsentButton(app)
         

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -50,8 +50,8 @@ final class ViewsTests: TestAppUITests {
         
         XCTAssert(app.staticTexts["First Title"].exists)
         XCTAssert(app.staticTexts["Second Title"].exists)
-        XCTAssert(app.staticTexts["Given Name"].exists)
-        XCTAssert(app.staticTexts["Family Name"].exists)
+        XCTAssert(app.staticTexts["First Name"].exists)
+        XCTAssert(app.staticTexts["Last Name"].exists)
         
         app.textFields["First Placeholder"].enter(value: "Le")
         app.textFields["Second Placeholder"].enter(value: "Stan")

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -56,8 +56,8 @@ final class ViewsTests: TestAppUITests {
         app.textFields["First Placeholder"].enter(value: "Le")
         app.textFields["Second Placeholder"].enter(value: "Stan")
         
-        app.textFields["Enter your given name ..."].enter(value: "land")
-        app.textFields["Enter your family name ..."].enter(value: "ford")
+        app.textFields["Enter your first name ..."].enter(value: "land")
+        app.textFields["Enter your last name ..."].enter(value: "ford")
         
         XCTAssert(app.textFields["Leland"].exists)
         XCTAssert(app.textFields["Stanford"].exists)


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Make name localization in onboarding configurable

## :recycle: Current situation & Problem
Based on user feedback, the terms *Given Name* and *Family Name* in the onboarding module are confusing, since most apps in US English use *First Name* and *Last Name*. This is also consistent with ResearchKit's [registration](http://researchkit.org/docs/docs/Account/Account.html) and [consent](http://researchkit.org/docs/docs/InformedConsent/InformedConsent.html) modules and CardinalKit Classic.

At the moment, the name localization in the Consent view is not configurable.

## :bulb: Proposed solution
- Updates the default english localization to replace *Given Name* with *First Name* and *Family Name* with *Last Name*. The account module is also updated in addition to the onboarding module, to keep these consistent.
- Makes name localization configurable by exposing these properties in the Consent initializer.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

