### PR TITLE
Add CollectSamples Option for the HealthKit Module

### DIFF
--- a/Sources/HealthKitDataSource/CollectSample/CollectSample.swift
+++ b/Sources/HealthKitDataSource/CollectSample/CollectSample.swift
@@ -11,32 +11,28 @@ import HealthKit
 
 
 /// Collects a specificied `HKSampleType`  in the ``HealthKit`` component.
-public struct CollectSample<SampleType: HKSampleType>: HealthKitDataSourceDescription {
-    let sampleType: SampleType
-    let deliverySetting: HealthKitDeliverySetting
+public struct CollectSample: HealthKitDataSourceDescription {
+    private let collectSamples: CollectSamples
     
     
     public var sampleTypes: Set<HKSampleType> {
-        [sampleType]
+        collectSamples.sampleTypes
     }
     
     
     /// - Parameters:
     ///   - sampleType: The `HKSampleType` that should be collected
     ///   - deliverySetting: The ``HealthKitDeliverySetting`` that should be used to collect the sample type. `.manual` is the default argument used.
-    public init(_ sampleType: SampleType, deliverySetting: HealthKitDeliverySetting = .manual()) {
-        self.sampleType = sampleType
-        self.deliverySetting = deliverySetting
+    public init<S: HKSampleType>(_ sampleType: S, deliverySetting: HealthKitDeliverySetting = .manual()) {
+        self.collectSamples = CollectSamples([sampleType], deliverySetting: deliverySetting)
     }
     
     
-    public func dataSource<S: Standard>(healthStore: HKHealthStore, standard: S, adapter: HealthKit<S>.HKSampleAdapter) -> HealthKitDataSource {
-        HealthKitSampleDataSource<S, SampleType>(
-            healthStore: healthStore,
-            standard: standard,
-            sampleType: sampleType,
-            deliverySetting: deliverySetting,
-            adapter: adapter
-        )
+    public func dataSources<S: Standard>(
+        healthStore: HKHealthStore,
+        standard: S,
+        adapter: HealthKit<S>.HKSampleAdapter
+    ) -> [any HealthKitDataSource] {
+        collectSamples.dataSources(healthStore: healthStore, standard: standard, adapter: adapter)
     }
 }

--- a/Sources/HealthKitDataSource/CollectSample/CollectSamples.swift
+++ b/Sources/HealthKitDataSource/CollectSample/CollectSamples.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+import HealthKit
+
+
+/// Collects `HKSampleType`s  in the ``HealthKit`` component.
+public struct CollectSamples: HealthKitDataSourceDescription {
+    public let sampleTypes: Set<HKSampleType>
+    let deliverySetting: HealthKitDeliverySetting
+    
+    
+    /// - Parameters:
+    ///   - sampleType: The set of `HKSampleType`s that should be collected
+    ///   - deliverySetting: The ``HealthKitDeliverySetting`` that should be used to collect the sample type. `.manual` is the default argument used.
+    public init(_ sampleTypes: Set<HKSampleType>, deliverySetting: HealthKitDeliverySetting = .manual()) {
+        self.sampleTypes = sampleTypes
+        self.deliverySetting = deliverySetting
+    }
+    
+    
+    public func dataSources<S: Standard>(
+        healthStore: HKHealthStore,
+        standard: S,
+        adapter: HealthKit<S>.HKSampleAdapter
+    ) -> [any HealthKitDataSource] {
+        sampleTypes.map { sampleType in
+            HealthKitSampleDataSource<S>(
+                healthStore: healthStore,
+                standard: standard,
+                sampleType: sampleType,
+                deliverySetting: deliverySetting,
+                adapter: adapter
+            )
+        }
+    }
+}

--- a/Sources/HealthKitDataSource/CollectSample/HealthKitSampleDataSource.swift
+++ b/Sources/HealthKitDataSource/CollectSample/HealthKitSampleDataSource.swift
@@ -11,11 +11,11 @@ import HealthKit
 import SwiftUI
 
 
-final class HealthKitSampleDataSource<ComponentStandard: Standard, SampleType: HKSampleType>: HealthKitDataSource {
+final class HealthKitSampleDataSource<ComponentStandard: Standard>: HealthKitDataSource {
     let healthStore: HKHealthStore
     let standard: ComponentStandard
     
-    let sampleType: SampleType
+    let sampleType: HKSampleType
     let predicate: NSPredicate?
     let deliverySetting: HealthKitDeliverySetting
     let adapter: HealthKit<ComponentStandard>.HKSampleAdapter
@@ -33,7 +33,7 @@ final class HealthKitSampleDataSource<ComponentStandard: Standard, SampleType: H
     required init( // swiftlint:disable:this function_default_parameter_at_end
         healthStore: HKHealthStore,
         standard: ComponentStandard,
-        sampleType: SampleType,
+        sampleType: HKSampleType,
         predicate: NSPredicate? = nil, // We order the parameters in a logical order and therefore don't put the predicate at the end here.
         deliverySetting: HealthKitDeliverySetting,
         adapter: HealthKit<ComponentStandard>.HKSampleAdapter
@@ -46,7 +46,7 @@ final class HealthKitSampleDataSource<ComponentStandard: Standard, SampleType: H
         
         if predicate == nil {
             self.predicate = HKQuery.predicateForSamples(
-                withStart: HealthKitSampleDataSource<ComponentStandard, SampleType>.loadDefaultQueryDate(for: sampleType),
+                withStart: HealthKitSampleDataSource<ComponentStandard>.loadDefaultQueryDate(for: sampleType),
                 end: nil,
                 options: .strictEndDate
             )
@@ -56,7 +56,7 @@ final class HealthKitSampleDataSource<ComponentStandard: Standard, SampleType: H
     }
     
     
-    private static func loadDefaultQueryDate(for sampleType: SampleType) -> Date {
+    private static func loadDefaultQueryDate(for sampleType: HKSampleType) -> Date {
         let defaultPredicateDateUserDefaultsKey = UserDefaults.Keys.healthKitDefaultPredicateDatePrefix.appending(sampleType.identifier)
         guard let date = UserDefaults.standard.object(forKey: defaultPredicateDateUserDefaultsKey) as? Date else {
             // We start date collection at the previous full minute mark to make the

--- a/Sources/HealthKitDataSource/HealthKit.swift
+++ b/Sources/HealthKitDataSource/HealthKit.swift
@@ -61,7 +61,7 @@ public final class HealthKit<ComponentStandard: Standard>: Module {
     let adapter: HKSampleAdapter
     lazy var healthKitComponents: [any HealthKitDataSource] = {
         healthKitDataSourceDescriptions
-            .map { $0.dataSource(healthStore: healthStore, standard: standard, adapter: adapter) }
+            .flatMap { $0.dataSources(healthStore: healthStore, standard: standard, adapter: adapter) }
     }()
     
     

--- a/Sources/HealthKitDataSource/HealthKitDataSource/HealthKitDataSourceDescription.swift
+++ b/Sources/HealthKitDataSource/HealthKitDataSource/HealthKitDataSourceDescription.swift
@@ -16,10 +16,10 @@ public protocol HealthKitDataSourceDescription {
     var sampleTypes: Set<HKSampleType> { get }
     
     
-    /// The ``HealthKitDataSourceDescription/dataSource(healthStore:standard:adapter:)`` method creates a ``HealthKitDataSource`` when the HealthKit component is instantiated.
+    /// The ``HealthKitDataSourceDescription/dataSources(healthStore:standard:adapter:)`` method creates ``HealthKitDataSource`` swhen the HealthKit component is instantiated.
     /// - Parameters:
     ///   - healthStore: The `HKHealthStore` instance that the queries should be performed on.
     ///   - standard: The `Standard` instance that is used in the software system.
     ///   - adapter: An adapter that can adapt HealthKit data to the corresponding data standard.
-    func dataSource<S: Standard>(healthStore: HKHealthStore, standard: S, adapter: HealthKit<S>.HKSampleAdapter) -> HealthKitDataSource
+    func dataSources<S: Standard>(healthStore: HKHealthStore, standard: S, adapter: HealthKit<S>.HKSampleAdapter) -> [HealthKitDataSource]
 }


### PR DESCRIPTION
# Add CollectSamples Option for the HealthKit Module

## :recycle: Current situation & Problem
- The CardinalKit HealthKit Module currently only supports adding an individual HealthKit type per configuration closure.

## :bulb: Proposed solution
- This PR adds the `CollectSamples` option to specify multiple HealthKit permission types for the HealthKit Module.

### Testing
- The current UI tests cover all the uses cases as the `CollectSample` type now uses the `CollectSamples` type in the background.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

